### PR TITLE
Fix crash when closing video window

### DIFF
--- a/WWDC/VideoWindowController.swift
+++ b/WWDC/VideoWindowController.swift
@@ -53,9 +53,7 @@ class VideoWindowController: NSWindowController {
         }
         
         NSNotificationCenter.defaultCenter().addObserverForName(NSWindowWillCloseNotification, object: self.window, queue: nil) { _ in
-            if self.transcriptWC.window != nil {
-               self.transcriptWC.close()
-            }
+            self.transcriptWC?.close()
             
             self.player?.pause()
         }


### PR DESCRIPTION
Pressing the red "x" button in the video window while watching a video is crashing. Switch to optional chaining to fix this.