### PR TITLE
Improve session default sorting. Sort by year, then by session number.

### DIFF
--- a/WWDC/DataStore.swift
+++ b/WWDC/DataStore.swift
@@ -36,7 +36,7 @@ class DataStore: NSObject {
 			doFetchSessions(completionHandler)
 		} else {
 			let internalServiceURL = NSURL(string: _internalServiceURL)
-			
+
 			URLSession.dataTaskWithURL(internalServiceURL!, completionHandler: { [unowned self] data, response, error in
 				if data == nil {
 					completionHandler(false, [])
@@ -86,7 +86,15 @@ class DataStore: NSObject {
                     
                     sessions.append(session)
                 }
-                
+				
+				sessions = sessions.sorted({ (sessionA: Session, sessionB: Session) -> Bool in
+					if(sessionA.year == sessionB.year) {
+						return sessionA.id < sessionB.id
+					} else {
+						return sessionA.year > sessionB.year
+					}
+				})
+
                 completionHandler(true, sessions)
             } else {
                 completionHandler(false, [])


### PR DESCRIPTION
While using the app, I found that it simply takes Apple's sorting of the sessions (which is seemingly random) and passes it right along.

IMHO sorting by year in descending order, then sorting by session in ascending order is the most sensible "default". Reasoning: It makes sense to compartmentalize each year of WWDC into it's own set of sessions and then within each year, each of the tracks follows a progression (often of introduction sessions, then advanced sessions), so sorting by session number makes sense as well.

In the future I'd love to add different sorting options, so this is just a start.