### PR TITLE
Update StringExtensions.swift

### DIFF
--- a/WWDC/StringExtensions.swift
+++ b/WWDC/StringExtensions.swift
@@ -11,13 +11,7 @@ import Foundation
 extension String {
     
     var boolValue: Bool {
-        get {
-            if self.lowercaseString == "yes" || self.lowercaseString == "true" || self.toInt() > 0 {
-                return true
-            } else {
-                return false
-            }
-        }
+        return (self as NSString).boolValue
     }
     
 }


### PR DESCRIPTION
Since `String` is really an `NSString`, you can simply cast it and use the built-in `boolValue` which does the right thing for strings like `true`, `false`, `YES`, `NO`, `0`, `1` and a few more.