### PR TITLE
[CI] Build with CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+machine:
+  environment:
+    LANG: en_US.UTF-8
+    LC_CTYPE: en_US.UTF-8
+  xcode:
+    version: "6.3.1"
+test:
+  override:
+    - set -o pipefail && xcodebuild -project 'WWDC.xcodeproj' -scheme 'WWDC' 
+      clean build | xcpretty -c


### PR DESCRIPTION
Thanks for a great app! I've added CI builds with [CircleCI](https://circleci.com), which supports Xcode 6.3.1/Swift 1.2 and is free for open-source projects.

If you're keen on this, to fully set this up:

1. Merge this PR
2. Log into [CircleCI](https://circleci.com) with your Github user
3. Add/follow the WWDC project to start your first build
4. Cancel the first build, since it is running on Ubuntu and not OS X
5. In CircleCI's "Experimental Settings" for this project, enable "iOS build" and probably also "project fork pull requests" so that PRs will be built
6. Email sayhi@circleci.com and ask for your user to be added to the OS X/iOS beta. In my experience they'll enable it for you within an hour or so.
