### PR TITLE
Allow platform sidebar text color to be inverted on selection

### DIFF
--- a/WWDC/Base.lproj/Main.storyboard
+++ b/WWDC/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D131" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7702"/>
     </dependencies>
@@ -804,7 +804,7 @@ CA
                                                                             <rect key="frame" x="404" y="24" width="42" height="11"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Platform" id="QG9-E2-JGn">
                                                                                 <font key="font" metaFont="miniSystem"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>


### PR DESCRIPTION
Changes the Platform sidebar label to controlTextColor which automatically inverts its color on selection:
![screen shot 2015-05-09 at 10 12 45 am](https://cloud.githubusercontent.com/assets/712727/7547651/d2b121a8-f634-11e4-915f-a17eb595534f.png)
