### PR TITLE
Fix the crash when video is missing transcript

### DIFF
--- a/ASCIIwwdc/ASCIIwwdc/ASCIIWWDCClient.m
+++ b/ASCIIwwdc/ASCIIwwdc/ASCIIWWDCClient.m
@@ -47,10 +47,18 @@
         NSDictionary *transcriptInfo = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonSerializationError];
         if (jsonSerializationError) {
             callback(NO, nil);
+            return;
         }
         
         NSArray *annotations = transcriptInfo[@"annotations"];
         NSArray *timecodes = transcriptInfo[@"timecodes"];
+        
+        // For transcripts that are unavailable objects for keys annotations, timecodes are nil values represented using NSNull. Causing the app to crash when lines mutable array is initialized with null object count
+        if ([annotations isKindOfClass:[NSNull class]] || [timecodes isKindOfClass:[NSNull class]]) {
+            callback(NO, nil);
+            return;
+        }
+        
         NSMutableArray *lines = [[NSMutableArray alloc] initWithCapacity:annotations.count];
         
         for (NSString *annotation in annotations) {


### PR DESCRIPTION
Launch any 2011 video and then view -> transcript crashes the app.

Fix:-
For transcripts that have unavailable objects for keys annotations, timecodes are nil values represented using NSNull. This is causing the app to crash when lines mutable array is initialized with null object count. Fixed by checking annotations or timecodes is NSNull kind of class.