### PR TITLE
Fix crash when computer sleeps

### DIFF
--- a/WWDC/DataStore.swift
+++ b/WWDC/DataStore.swift
@@ -200,7 +200,7 @@ class DataStore: NSObject {
     
     func checkForLiveEvent(completionHandler: (Bool, LiveEvent?) -> ()) {
         let task = URLSession.dataTaskWithURL(liveURL) { data, response, error in
-            if data == nil {
+            if data == nil || data.length == 0 {
                 completionHandler(false, nil)
                 return
             }


### PR DESCRIPTION
When the computer sleeps in the middle of a checkForLiveEvent, request data comes back empty, but non-nil.