### PR TITLE
Localize the date/time used in the live banner

### DIFF
--- a/WWDC/LiveEventBannerViewController.swift
+++ b/WWDC/LiveEventBannerViewController.swift
@@ -45,6 +45,14 @@ class LiveEventBannerViewController: NSViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        var observer: NSObjectProtocol?
+        observer = NSNotificationCenter.defaultCenter().addObserverForName(NSCurrentLocaleDidChangeNotification, object: nil, queue: NSOperationQueue.mainQueue()) { [weak self] (notification) -> Void in
+            if let this = self {
+                this.updateUI()
+            } else if let observer = observer {
+                NSNotificationCenter.defaultCenter().removeObserver(observer)
+            }
+        }
     }
     
     private func updateUI() {
@@ -53,7 +61,9 @@ class LiveEventBannerViewController: NSViewController {
             NSNotificationCenter.defaultCenter().postNotificationName(LiveEventBannerVisibilityChangedNotification, object: nil)
             if let date = event.startsAt {
                 let formatter = NSDateFormatter()
-                formatter.dateFormat = "MM-dd @ HH:mm"
+                let dateFormat = NSDateFormatter.dateFormatFromTemplate("Md", options: 0, locale: NSLocale.currentLocale()) ?? "M-d"
+                let timeFormat = NSDateFormatter.dateFormatFromTemplate("jjmm", options: 0, locale: NSLocale.currentLocale()) ?? "HH':'mm"
+                formatter.dateFormat = "\(dateFormat) '@' \(timeFormat)"
                 
                 titleLabel.stringValue = "\(event.title) (\(formatter.stringFromDate(date)))"
             } else {


### PR DESCRIPTION
This was primarily motivated by a desire to stop seeing 24-hour time.