### PR TITLE
The updated link will also work with curl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Don't like WWDC's website? Use this app to watch WWDC sessions on your Mac.
 
-To download the latest release, [click here](https://github.com/insidegui/WWDC/blob/master/Releases/WWDC_latest.zip?raw=true).
+To download the latest release, [click here](https://raw.githubusercontent.com/insidegui/WWDC/master/Releases/WWDC_latest.zip).
 
 You can also install using [Homebrew Cask](http://caskroom.io):
 


### PR DESCRIPTION
the old download link works in browser as browser will redirect to the files. However, curl does not recognize the redirect and fails to download.  