### PR TITLE
Search using keywords.

### DIFF
--- a/WWDC/SearchOperation.swift
+++ b/WWDC/SearchOperation.swift
@@ -104,10 +104,9 @@ class SearchOperation: NSOperation {
                     }
                     
                     if let query: String = qualifiers["_query"] as? String {
-                        if query != "" {
-                            if let range = session.title.rangeOfString(query, options: .CaseInsensitiveSearch | .DiacriticInsensitiveSearch, range: nil, locale: nil) {
-                                //Nothing here...
-                            } else {
+                        // match all words in session title
+                        for word in query.words() {
+                            if session.title.rangeOfString(word, options: .CaseInsensitiveSearch | .DiacriticInsensitiveSearch, range: nil, locale: nil) == nil {
                                 return false
                             }
                         }

--- a/WWDC/StringExtensions.swift
+++ b/WWDC/StringExtensions.swift
@@ -20,4 +20,14 @@ extension String {
         }
     }
     
+    func words() -> [String] {
+        
+        var words = [String]()
+        let range = Range<String.Index>(start: self.startIndex, end: self.endIndex)
+        self.enumerateSubstringsInRange(range, options: NSStringEnumerationOptions.ByWords) { (substring, _, _, _) -> () in
+            words.append(substring)
+        }
+        return words
+    }
+    
 }


### PR DESCRIPTION
Search using keywords instead of the literal text typed in the search field.

This allows searching sessions even if you don't know the exact session title.

For instance, typing "new cocoa" would find al sessions like "What's new in cocoa..."  without the need to type the exact session name. And you could also fine tune that search to "new cocoa touch" to focus even more the search.
