### PR TITLE
Auto-create videos folder when clicking “Reveal in Finder” in preferences

### DIFF
--- a/WWDC/PreferencesWindowController.swift
+++ b/WWDC/PreferencesWindowController.swift
@@ -90,6 +90,12 @@ class PreferencesWindowController: NSWindowController {
     @IBAction func revealInFinder(sender: NSButton) {
         let path = Preferences.SharedPreferences().localVideoStoragePath
         let root = path.stringByDeletingLastPathComponent
+
+        let fileManager = NSFileManager.defaultManager()
+        if !fileManager.fileExistsAtPath(path) {
+            fileManager.createDirectoryAtPath(path, withIntermediateDirectories: false, attributes: nil, error: nil)
+        }
+
         NSWorkspace.sharedWorkspace().selectFile(path, inFileViewerRootedAtPath: root)
     }
     


### PR DESCRIPTION
It's kind of annoying when you press that "Reveal" button and nothing happens because the directory wasn't created yet (it's only created once a video downloads completely) - I thought something was broken there.
