### PR TITLE
Open downloads window on single-click on the indicator control

### DIFF
--- a/WWDC/DownloadProgressViewController.swift
+++ b/WWDC/DownloadProgressViewController.swift
@@ -53,7 +53,7 @@ class DownloadProgressViewController: NSViewController {
 	
 	private func updateUI()
 	{
-        progressIndicator?.doubleAction = "showDownloadsWindow:"
+        progressIndicator?.action = "showDownloadsWindow:"
         
 		if let session = session {
 			if session.hd_url != nil {


### PR DESCRIPTION
IMHO this is more intuitive than having to double-click it - I thought this actually wasn't implemented because I clicked it and nothing happens, I only discovered later that it does in fact open the window if you double-click it. Since there's no other single-click attached to it, there's no point in making this harder to find.