### PR TITLE
Fix crash when clicking "Mark as watched" button.

### DIFF
--- a/WWDC/ArrayExtensions.swift
+++ b/WWDC/ArrayExtensions.swift
@@ -8,31 +8,11 @@
 
 import Foundation
 
-extension Array {
-    mutating func remove<U: Equatable>(object: U) {
-        var index: Int?
-        for (idx, itemToRemove) in self.enumerate() {
-            if let to = itemToRemove as? U {
-                if object == to {
-                    index = idx
-                }
-            }
-        }
-        
-        if(index != nil) {
-            self.removeAtIndex(index!)
-        }
-    }
-    
-    func contains<U: Equatable>(object: U) -> Bool {
-        for itemToCompare in self {
-            if let to = itemToCompare as? U {
-                if object == to {
-                    return true
-                }
-            }
-        }
-        
-        return false
+extension RangeReplaceableCollectionType where Generator.Element: Equatable {
+    mutating func remove(object: Generator.Element) {
+        guard let index = indexOf(object)
+            else { return }
+
+        self.removeAtIndex(index)
     }
 }

--- a/WWDC/VideoDetailsViewController.swift
+++ b/WWDC/VideoDetailsViewController.swift
@@ -133,10 +133,12 @@ class VideoDetailsViewController: NSViewController {
         }
         
         actionButtonsController.toggleWatchedCallback = { [unowned self] in
-            if self.session!.progress < 100 {
-                self.session!.progress = 100
-            } else {
-                self.session!.progress = 0
+            WWDCDatabase.sharedDatabase.doChanges {
+                if self.session!.progress < 100 {
+                    self.session!.progress = 100
+                } else {
+                    self.session!.progress = 0
+                }
             }
         }
         


### PR DESCRIPTION
The handler for the "Mark as watched/unwatched" button doesn't wrap changes to the `Session` object in calls to `beginWrite()` / `endWrite()`. This fixes that crash and replaces a superfluous Array extension with a more efficient, Swift 2.0-based extension.