### PR TITLE
fix filter bar's wrong frame when use mouse

### DIFF
--- a/ViewUtils/ViewUtils/GRScrollView.h
+++ b/ViewUtils/ViewUtils/GRScrollView.h
@@ -14,6 +14,7 @@
 
 - (void)scrollViewDidScroll:(GRScrollView *__nonnull)scrollView;
 - (void)scrollViewDidEndDragging:(GRScrollView *__nonnull)scrollView;
+- (void)mouseWheelDidScroll:(GRScrollView *__nonnull)scrollView;
 
 @end
 

--- a/ViewUtils/ViewUtils/GRScrollView.m
+++ b/ViewUtils/ViewUtils/GRScrollView.m
@@ -14,6 +14,11 @@
 {
     [super scrollWheel:theEvent];
     
+    if (theEvent.phase == NSEventPhaseNone && theEvent.momentumPhase == NSEventPhaseNone && [self.delegate respondsToSelector:@selector(mouseWheelDidScroll:)]) {
+        [self.delegate mouseWheelDidScroll:self];
+        return;
+    }
+    
     if (theEvent.phase == NSEventPhaseEnded && theEvent.deltaX == 0.0 && theEvent.deltaY == 0.0) if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDragging:)]) [self.delegate scrollViewDidEndDragging:self];
     if ([self.delegate respondsToSelector:@selector(scrollViewDidScroll:)]) [self.delegate scrollViewDidScroll:self];
 }

--- a/WWDC/FilterBarController.swift
+++ b/WWDC/FilterBarController.swift
@@ -54,6 +54,7 @@ class FilterBarController: NSViewController, GRScrollViewDelegate {
     }
     
     override func viewWillAppear() {
+        super.viewWillAppear()
         view.frame = CGRectMake(0, accessoryViewBaseY, CGRectGetWidth(view.frame), 44.0)
     }
     


### PR DESCRIPTION
Hi, @insidegui 
Thx for the nice repo, I enjoyed a lot and learned a lot.
When I use it (with a mouse), I find the `filter bar` will have a wrong vision when scroll. So I try to fix.
Finally I find out that when I use mouse wheel, the `theEvent.phase` and `theEvent.momentumPhase` is equal to `NSEventPhaseNone`, so it never call the method `-scrollViewDidEndDragging:`, i fix it as the pr.
Maybe it's not the most elegant way to deal with, just give an idea.
Thanks again!
