### PR TITLE
Updates tableView when user de-favorites session

### DIFF
--- a/WWDC/VideosViewController.swift
+++ b/WWDC/VideosViewController.swift
@@ -304,8 +304,10 @@ class VideosViewController: NSViewController, NSTableViewDelegate, NSTableViewDa
             WWDCDatabase.sharedDatabase.doChanges {
                 session.favorite = false
             }
+			tableView.removeRowsAtIndexes(NSIndexSet(index: tableView.clickedRow), withAnimation: NSTableViewAnimationOptions.SlideUp)
         } else {
             doMassiveSessionPropertyUpdate(.Favorite(false))
+			tableView.removeRowsAtIndexes(tableView.selectedRowIndexes, withAnimation: NSTableViewAnimationOptions.SlideUp)
         }
     }
     

--- a/WWDC/VideosViewController.swift
+++ b/WWDC/VideosViewController.swift
@@ -304,10 +304,10 @@ class VideosViewController: NSViewController, NSTableViewDelegate, NSTableViewDa
             WWDCDatabase.sharedDatabase.doChanges {
                 session.favorite = false
             }
-			tableView.removeRowsAtIndexes(NSIndexSet(index: tableView.clickedRow), withAnimation: NSTableViewAnimationOptions.SlideUp)
+            tableView.removeRowsAtIndexes(NSIndexSet(index: tableView.clickedRow), withAnimation: NSTableViewAnimationOptions.SlideUp)
         } else {
             doMassiveSessionPropertyUpdate(.Favorite(false))
-			tableView.removeRowsAtIndexes(tableView.selectedRowIndexes, withAnimation: NSTableViewAnimationOptions.SlideUp)
+            tableView.removeRowsAtIndexes(tableView.selectedRowIndexes, withAnimation: NSTableViewAnimationOptions.SlideUp)
         }
     }
     


### PR DESCRIPTION
Fixes #125 

When the user de-selects a favorited section, the tableView removes the row(s) with a slideUp animation. 
