### PR TITLE
Temporarily disable video controls while loading

### DIFF
--- a/WWDC/VideoWindowController.swift
+++ b/WWDC/VideoWindowController.swift
@@ -91,6 +91,7 @@ class VideoWindowController: NSWindowController {
                 player = AVPlayer(URL: url)
                 addRateObserver(player: player!)
                 playerView.player = player
+                playerView.controlsStyle = .None
                 
                 // SESSION
                 player?.currentItem!.asset.loadValuesAsynchronouslyForKeys(["tracks"]) {
@@ -109,6 +110,7 @@ class VideoWindowController: NSWindowController {
                         }
                         self.player?.play()
                         self.progressIndicator.stopAnimation(nil)
+                        self.playerView.controlsStyle = .Floating
                     }
                 }
             }


### PR DESCRIPTION
This prevents a crash when a user attempts to click on the time slider when the video is still loading by hiding the controls while the video is loading.

