### PR TITLE
Do not skip all downloads but only invalid downloads

### DIFF
--- a/WWDC/DownloadListWindowController.swift
+++ b/WWDC/DownloadListWindowController.swift
@@ -162,8 +162,8 @@ class DownloadListWindowController: NSWindowController, NSTableViewDelegate, NST
 		let tasks = self.videoStore.allTasks()
 
         for task in tasks {
-            guard let url = task.originalRequest?.URL?.absoluteString else { return }
-            guard let session = WWDCDatabase.sharedDatabase.realm.objects(Session.self).filter("hdVideoURL = %@", url).first else { return }
+            guard let url = task.originalRequest?.URL?.absoluteString else { continue }
+            guard let session = WWDCDatabase.sharedDatabase.realm.objects(Session.self).filter("hdVideoURL = %@", url).first else { continue }
             let item = DownloadListItem(url: url, session: session, task: task)
             self.items.append(item)
 		}


### PR DESCRIPTION
I didn't see any downloads and I could not add new downloads. After small debugging I have found the issue.