### PR TITLE
Added shortcut keys 'p' and 'n' to move pages in the slides window

### DIFF
--- a/WWDC/PDFWindowController.swift
+++ b/WWDC/PDFWindowController.swift
@@ -107,4 +107,16 @@ class PDFWindowController: NSWindowController {
         }
     }
     
+    override func keyDown(theEvent: NSEvent) {
+        switch theEvent.keyCode {
+        case 35: // p
+            pdfView.goToPreviousPage(self)
+        case 45: // n
+            pdfView.goToNextPage(self)
+        default:
+            super.keyDown(theEvent)
+            break
+        }
+    }
+
 }


### PR DESCRIPTION
Added to WWDC/PDFWindowController.swift to make keys p and n move the exact previous and next page of the PDF (#168).
## Background

In the current version of WWDC.app, the space key works as a halfway moving in slide view. I would like to move the exact next or previous page in the slide view when I look at slides PDFs.
