### PR TITLE
Feature: Hidden Preference for Realm Database Path

### DIFF
--- a/WWDC/Preferences.swift
+++ b/WWDC/Preferences.swift
@@ -35,6 +35,7 @@ class Preferences {
         static let automaticRefreshEnabled = "automaticRefreshEnabled"
 		static let floatOnTopEnabled = "floatOnTopEnabled"
         static let automaticRefreshSuggestionPresentedAt = "automaticRefreshSuggestionPresentedAt"
+        static let realmDatabasePath = "realmDatabasePath"
         
         struct transcript {
             static let font = "transcript.font"
@@ -325,6 +326,15 @@ class Preferences {
         }
         set {
             defaults.setObject(newValue, forKey: Keys.automaticRefreshSuggestionPresentedAt)
+        }
+    }
+    
+    var databasePath: String? {
+        get {
+            return defaults.objectForKey(Keys.realmDatabasePath) as? String
+        }
+        set {
+            defaults.setObject(newValue, forKey: Keys.realmDatabasePath)
         }
     }
 

--- a/WWDC/WWDCDatabase.swift
+++ b/WWDC/WWDCDatabase.swift
@@ -79,7 +79,7 @@ let TranscriptIndexingDidStopNotification = "TranscriptIndexingDidStopNotificati
         
         let preferences = Preferences.SharedPreferences()
         if let realmPath = preferences.databasePath {
-            realmConfiguration.fileURL = NSURL(fileURLWithPath: realmPath)
+            realmConfiguration.fileURL = NSURL(fileURLWithPath: realmPath).URLByAppendingPathComponent("default.realm")
         }
         
         Realm.Configuration.defaultConfiguration = realmConfiguration

--- a/WWDC/WWDCDatabase.swift
+++ b/WWDC/WWDCDatabase.swift
@@ -69,13 +69,18 @@ let TranscriptIndexingDidStopNotification = "TranscriptIndexingDidStopNotificati
     private let currentDBVersion = UInt64(6)
     
     private func configureRealm() {
-        let realmConfiguration = Realm.Configuration(schemaVersion: currentDBVersion, migrationBlock: { migration, oldVersion in
+        var realmConfiguration = Realm.Configuration(schemaVersion: currentDBVersion, migrationBlock: { migration, oldVersion in
             if oldVersion == 0 && self.currentDBVersion >= 5 {
                 NSLog("Migrating data from version 0 to version \(self.currentDBVersion)")
                 // app config must be invalidated for this version update
                 migration.deleteData("AppConfig")
             }
         })
+        
+        let preferences = Preferences.SharedPreferences()
+        if let realmPath = preferences.databasePath {
+            realmConfiguration.fileURL = NSURL(fileURLWithPath: realmPath)
+        }
         
         Realm.Configuration.defaultConfiguration = realmConfiguration
     }


### PR DESCRIPTION
I noticed in the roadmap there are plans for synchronizing data between devices in the future. Until then, I've put together a workaround to store the Realm database inside an arbitrary folder by writing a hidden preference:

`defaults write br.com.guilhermerambo.WWDC realmDatabasePath "/Users/thaddeus/Dropbox/WWDCAppDatabase"`

There are likely quite a few issues with this (especially with Dropbox), but it works to serve as a backup of my configuration at present. I've started working on UI updates to the preferences window to surface this feature, but I feel that only further exposes the limitations, so I've stopped working on that for now.

Given the limitations of this functionality, I'm not going to be offended by it not being merged. However, if it's something that might be useful to others, it could probably be cleaned up a bit more and treated as an undocumented/hidden feature.