### PR TITLE
Ensured boundaryObserver is immediately set to nil if removed

### DIFF
--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -116,6 +116,7 @@ final class VideoPlayerViewController: NSViewController {
         if let oldPlayer = oldValue {
             if let boundaryObserver = boundaryObserver {
                 oldPlayer.removeTimeObserver(boundaryObserver)
+				self.boundaryObserver = nil
             }
             
             playerView.player = nil


### PR DESCRIPTION
Fixes Issue #208 