### PR TITLE
Add support to cancelling download by clicking on the progress indicator

### DIFF
--- a/WWDC/AppCoordinator+SessionActions.swift
+++ b/WWDC/AppCoordinator+SessionActions.swift
@@ -14,6 +14,14 @@ import PlayerUI
 
 extension AppCoordinator: SessionActionsViewControllerDelegate {
     
+    func sessionActionsDidSelectCancelDownload(_ sender: NSView?) {
+        guard let viewModel = selectedViewModelRegardlessOfTab else { return }
+        
+        guard let url = viewModel.session.assets.filter({ $0.assetType == .hdVideo }).first?.remoteURL else { return }
+        
+        _ = DownloadManager.shared.cancelDownload(url)
+    }
+    
     func sessionActionsDidSelectFavorite(_ sender: NSView?) {
         guard let viewModel = selectedViewModelRegardlessOfTab else { return }
         

--- a/WWDC/SessionActionsViewController.swift
+++ b/WWDC/SessionActionsViewController.swift
@@ -91,6 +91,7 @@ class SessionActionsViewController: NSViewController {
         pi.widthAnchor.constraint(equalToConstant: 24).isActive = true
         pi.heightAnchor.constraint(equalToConstant: 24).isActive = true
         pi.isHidden = true
+        pi.addGestureRecognizer(NSClickGestureRecognizer(target: self, action: #selector(cancelDownload(_:))))
         
         return pi
     }()
@@ -221,4 +222,6 @@ class SessionActionsViewController: NSViewController {
         delegate?.sessionActionsDidSelectShare(sender)
     }
     
+    @IBAction func cancelDownload(_ sender: NSView?) {
+    }
 }

--- a/WWDC/SessionActionsViewController.swift
+++ b/WWDC/SessionActionsViewController.swift
@@ -18,8 +18,8 @@ protocol SessionActionsViewControllerDelegate: class {
     func sessionActionsDidSelectFavorite(_ sender: NSView?)
     func sessionActionsDidSelectDownload(_ sender: NSView?)
     func sessionActionsDidSelectDeleteDownload(_ sender: NSView?)
+    func sessionActionsDidSelectCancelDownload(_ sender: NSView?)
     func sessionActionsDidSelectShare(_ sender: NSView?)
-    
 }
 
 class SessionActionsViewController: NSViewController {
@@ -223,5 +223,6 @@ class SessionActionsViewController: NSViewController {
     }
     
     @IBAction func cancelDownload(_ sender: NSView?) {
+        delegate?.sessionActionsDidSelectCancelDownload(sender)
     }
 }


### PR DESCRIPTION
That's a quick fix for the issue https://github.com/insidegui/WWDC/issues/209.

The concept is based on the iOS App Store's download handling system. I'm not 100% sure if it can be applied for macOS too.

If so, ideally we'd have a progress indicator with a square (cancel symbol) in the middle, like the iOS App Store does, so the user is aware of the feature.

However, I think it's still worth shipping it as a quick fix anyways 😊 :shipit: 

Thanks for the awesome project @insidegui, I love it <3