### PR TITLE
Removed unused variable assignment from PUIPlayerView

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -894,8 +894,6 @@ public final class PUIPlayerView: NSView {
         
         self.subtitlesGroup = subtitlesGroup
         
-        let currentMediaSelection = playerItem.currentMediaSelection
-        
         subtitlesButton.isHidden = false
         
         let menu = NSMenu()


### PR DESCRIPTION
Firstly I want to preface this by saying that it's not clear why this line was included in the first place and there may be a reason it exists. That being said, it doesn't appear to serve any purpose and the player runs without it.

An alternate solution to satisfy the compiler warning would be

```swift
_ = playerItem.currentMediaSelection
```