### PR TITLE
Add playback speed menu when right-clicking the player button

### DIFF
--- a/PlayerUI/Definitions/Speeds.swift
+++ b/PlayerUI/Definitions/Speeds.swift
@@ -14,7 +14,11 @@ public enum PUIPlaybackSpeed: Float {
     case midFast = 1.25
     case fast = 1.5
     case fastest = 2
-    
+  
+    public static var all: [PUIPlaybackSpeed] {
+        return [.slow, .normal, .midFast, .fast, .fastest]
+    }
+  
     var icon: NSImage {
         switch self {
         case .slow:
@@ -29,18 +33,14 @@ public enum PUIPlaybackSpeed: Float {
             return .PUISpeedTwo
         }
     }
-    
-    private var all: [PUIPlaybackSpeed] {
-        return [.slow, .normal, .midFast, .fast, .fastest]
-    }
-    
+
     public var next: PUIPlaybackSpeed {
-        guard let idx = all.index(of: self) else {
+        guard let idx = PUIPlaybackSpeed.all.index(of: self) else {
             fatalError("Tried to get next speed from nonsensical playback speed \(self). Probably missing in collection.")
         }
         
-        let nextIdx = idx + 1 < all.count ? idx + 1 : 0
+        let nextIdx = idx + 1 < PUIPlaybackSpeed.all.count ? idx + 1 : 0
         
-        return all[nextIdx]
+        return PUIPlaybackSpeed.all[nextIdx]
     }
 }

--- a/PlayerUI/Views/PUIButton.swift
+++ b/PlayerUI/Views/PUIButton.swift
@@ -31,6 +31,7 @@ public final class PUIButton: NSControl {
     }
     
     public var showsMenuOnLeftClick = false
+    public var showsMenuOnRightClick = false
     public var sendsActionOnMouseDown = false
     
     public var image: NSImage? {
@@ -164,7 +165,14 @@ public final class PUIButton: NSControl {
             NSApp.sendAction(action, to: target, from: self)
         }
     }
-    
+  
+    public override func rightMouseDown(with event: NSEvent) {
+        guard showsMenuOnRightClick else {
+          return
+        }
+        showMenu(with: event)
+    }
+
     private func showMenu(with event: NSEvent) {
         guard let menu = self.menu else { return }
         

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -982,7 +982,7 @@ public final class PUIPlayerView: NSView {
     fileprivate lazy var speedsMenu: NSMenu = {
         let m = NSMenu()
         for speed in PUIPlaybackSpeed.all {
-            let item = NSMenuItem(title: "\(speed.rawValue)x", action: #selector(didSelectSpeed(_:)), keyEquivalent: "")
+            let item = NSMenuItem(title: "\(String(format: "%g", speed.rawValue))x", action: #selector(didSelectSpeed(_:)), keyEquivalent: "")
             item.target = self
             item.representedObject = speed
             item.state = speed == self.playbackSpeed ? NSOnState : NSOffState

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -162,6 +162,7 @@ public final class PUIPlayerView: NSView {
             }
 
             updatePlaybackSpeedState()
+            updateSelectedMenuItem(forPlaybackSpeed: playbackSpeed)
         }
     }
     
@@ -557,7 +558,7 @@ public final class PUIPlayerView: NSView {
         
         return b
     }()
-    
+  
     fileprivate lazy var speedButton: PUIButton = {
         let b = PUIButton(frame: .zero)
         
@@ -565,6 +566,8 @@ public final class PUIPlayerView: NSView {
         b.target = self
         b.action = #selector(toggleSpeed(_:))
         b.toolTip = "Change playback speed"
+        b.menu = self.speedsMenu
+        b.showsMenuOnRightClick = true
         
         return b
     }()
@@ -973,7 +976,34 @@ public final class PUIPlayerView: NSView {
     @IBAction func showSubtitlesMenu(_ sender: PUIButton) {
         subtitlesMenu?.popUp(positioning: nil, at: .zero, in: sender)
     }
+  
+    // MARK: - Playback speeds
     
+    fileprivate lazy var speedsMenu: NSMenu = {
+        let m = NSMenu()
+        for speed in PUIPlaybackSpeed.all {
+            let item = NSMenuItem(title: "\(speed.rawValue)x", action: #selector(didSelectSpeed(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = speed
+            item.state = speed == self.playbackSpeed ? NSOnState : NSOffState
+            m.addItem(item)
+        }
+        return m
+    }()
+    
+    fileprivate func updateSelectedMenuItem(forPlaybackSpeed speed: PUIPlaybackSpeed) {
+        for item in speedsMenu.items {
+            item.state = (item.representedObject as? PUIPlaybackSpeed) == speed ? NSOnState : NSOffState
+        }
+    }
+    
+    @objc private func didSelectSpeed(_ sender: NSMenuItem) {
+        guard let speed = sender.representedObject as? PUIPlaybackSpeed else {
+            return
+        }
+        playbackSpeed = speed
+    }
+  
     // MARK: - Key commands
     
     private var keyDownEventMonitor: Any?


### PR DESCRIPTION
This PR adds a player playback speed menu when the user right-clicks on its button. I personally did this out of necessity, so I hope more people find it useful too.

Here's how it looks like:
<img width="279" alt="captura de ecra 2017-06-27 as 04 02 59" src="https://user-images.githubusercontent.com/1943188/27569162-f047c030-5aed-11e7-81e5-d200981b0f95.png">
