### PR TITLE
Implement window frame autosave

### DIFF
--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -64,7 +64,7 @@ final class AppCoordinator {
         
         DownloadManager.shared.start(with: storage)
         
-        self.tabController = WWDCTabViewController()
+        self.tabController = WWDCTabViewController(windowController: windowController)
         
         // Schedule
         self.scheduleController = SessionsSplitViewController(listStyle: .schedule)

--- a/WWDC/MainWindowController.swift
+++ b/WWDC/MainWindowController.swift
@@ -43,6 +43,7 @@ final class MainWindowController: NSWindowController {
         window.toolbar = NSToolbar(identifier: "WWDC")
         
         window.identifier = "main"
+        window.setFrameAutosaveName("main")
         window.minSize = NSSize(width: 1060, height: 700)
         
         windowDidLoad()

--- a/WWDC/PreferencesCoordinator.swift
+++ b/WWDC/PreferencesCoordinator.swift
@@ -29,7 +29,7 @@ final class PreferencesCoordinator {
     
     init() {
         self.windowController = PreferencesWindowController()
-        self.tabController = WWDCTabViewController()
+        self.tabController = WWDCTabViewController(windowController: self.windowController)
         
         // General
         self.generalController = GeneralPreferencesViewController.loadFromStoryboard()

--- a/WWDC/WWDCTabViewController.swift
+++ b/WWDC/WWDCTabViewController.swift
@@ -31,9 +31,15 @@ class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Ta
         return activeTabVar.asObservable()
     }
     
-    init() {
+    init(windowController: NSWindowController) {
         super.init(nibName: nil, bundle: nil)!
-        
+
+        // Preserve the window's size, essentially passing in saved window frame sizes
+        let superFrame = view.frame
+        if let windowFrame = windowController.window?.frame {
+            view.frame = NSRect(origin: superFrame.origin, size: windowFrame.size)
+        }
+
         identifier = "tabs"
     }
     


### PR DESCRIPTION
[Inspired by](https://github.com/ridiculousfish/HexFiend/pull/87) @shysaur.

The window now remembers how you had it, mostly relying on in-built (free) system features. Not sure if this is desired, but it bothered me. Beyond this, I'm working on preserving filter settings between launches.