### PR TITLE
Saves and restores filter state across launches

### DIFF
--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -209,7 +209,8 @@ final class AppCoordinator {
     private lazy var searchCoordinator: SearchCoordinator = {
         return SearchCoordinator(self.storage,
                                  sessionsController: self.scheduleController.listViewController,
-                                 videosController: self.videosController.listViewController)
+                                 videosController: self.videosController.listViewController,
+                                 restorationFiltersState: Preferences.shared.filtersState)
     }()
     
     private func setupSearch() {
@@ -288,6 +289,7 @@ final class AppCoordinator {
         Preferences.shared.activeTab = activeTab
         Preferences.shared.selectedScheduleItemIdentifier = selectedScheduleItemValue?.identifier
         Preferences.shared.selectedVideoItemIdentifier = selectedSessionValue?.identifier
+        Preferences.shared.filtersState = searchCoordinator.currentFiltersState()
     }
     
     private func restoreApplicationState() {

--- a/WWDC/FilterType.swift
+++ b/WWDC/FilterType.swift
@@ -8,10 +8,53 @@
 
 import Foundation
 
+typealias WWDCFiltersStateDictionary = [ String : [ FilterIdentifier.RawValue : WWDCFilterTypeDictionary ] ]
+typealias WWDCFilterTypeDictionary = [ String : Any ]
+
 protocol FilterType {
     
     var identifier: String { get set }
     var isEmpty: Bool { get }
     var predicate: NSPredicate? { get }
-    
+    func dictionaryRepresentation() -> WWDCFilterTypeDictionary
+
+}
+
+// Can't use WWDCFilterTypeDictionary as Value's type, likely a bug in Swift
+extension Dictionary where Key == String, Value == [ String : Any ] {
+
+    init?(filters: [FilterType]) {
+
+        self = [String : WWDCFilterTypeDictionary]()
+
+        for filter in filters {
+
+            guard let filterID = FilterIdentifier(rawValue: filter.identifier) else {
+                continue
+            }
+
+            switch filterID {
+            case .text:
+                //TextualFilter
+                self[filterID.rawValue] = filter.dictionaryRepresentation()
+            case .event:
+                fallthrough
+            case .focus:
+                fallthrough
+            case .track:
+                //MultipleChoiceFilter
+                self[filterID.rawValue] = filter.dictionaryRepresentation()
+            case .isFavorite:
+                fallthrough
+            case .isDownloaded:
+                fallthrough
+            case .isUnwatched:
+                //ToggleFilters
+                self[filterID.rawValue] = filter.dictionaryRepresentation()
+            }
+
+        }
+
+    }
+
 }

--- a/WWDC/MainWindowController.swift
+++ b/WWDC/MainWindowController.swift
@@ -11,6 +11,14 @@ import Cocoa
 enum MainWindowTab: Int {
     case schedule
     case videos
+
+    func stringValue() -> String {
+        var name = ""
+
+        debugPrint(self, separator: "", terminator: "", to: &name)
+
+        return name
+    }
 }
 
 extension Notification.Name {

--- a/WWDC/MultipleChoiceFilter.swift
+++ b/WWDC/MultipleChoiceFilter.swift
@@ -139,7 +139,6 @@ struct MultipleChoiceFilter: FilterType {
     func dictionaryRepresentation() -> WWDCFilterTypeDictionary {
         var dictionary: WWDCFilterTypeDictionary = WWDCFilterTypeDictionary()
 
-        dictionary["options"] = options.dictionaryRepresentation()
         dictionary["selectedOptions"] = selectedOptions.dictionaryRepresentation()
 
         return dictionary

--- a/WWDC/MultipleChoiceFilter.swift
+++ b/WWDC/MultipleChoiceFilter.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftyJSON
 
 struct FilterOption: Equatable {
     let title: String
@@ -26,16 +27,63 @@ struct FilterOption: Equatable {
     static func ==(lhs: FilterOption, rhs: FilterOption) -> Bool {
         return lhs.value == rhs.value
     }
+
+    func dictionaryRepresentation() -> [String : String] {
+        var dictionary = [String : String]()
+
+        dictionary["value"] = value
+        dictionary["title"] = title
+
+        return dictionary
+    }
+}
+
+extension Array where Element == FilterOption {
+
+    init?(_ fromArray: Array<Any>?) {
+
+        guard let fromArray = fromArray as? Array<Dictionary<String, String>> else {
+            return nil
+        }
+
+        self = Array<FilterOption>()
+
+        for i in fromArray {
+            if let title = i["title"], let value = i["value"] {
+                self.append(FilterOption(title: title, value: value))
+            }
+        }
+    }
+
+    func dictionaryRepresentation() -> Array<Dictionary<String, String>> {
+        var array = Array<Dictionary<String, String>>()
+
+        for option in self {
+            array.append(option.dictionaryRepresentation())
+        }
+
+        return array
+    }
+
 }
 
 struct MultipleChoiceFilter: FilterType {
-    
+
     var identifier: String
     var isSubquery: Bool
     var collectionKey: String
     var modelKey: String
     var options: [FilterOption]
-    var selectedOptions: [FilterOption]
+    private var _selectedOptions: [FilterOption] = [FilterOption]()
+    var selectedOptions: [FilterOption] {
+        get {
+            return _selectedOptions
+        }
+        set {
+            // For state preservation we ensure that selected options are actually part of the options that are available on this filter
+            _selectedOptions = newValue.filter { options.contains($0) }
+        }
+    }
     
     var emptyTitle: String
     
@@ -75,5 +123,25 @@ struct MultipleChoiceFilter: FilterType {
         
         return NSCompoundPredicate(orPredicateWithSubpredicates: subpredicates)
     }
-    
+
+    init(identifier: String, isSubquery: Bool, collectionKey: String, modelKey: String, options: [FilterOption], selectedOptions: [FilterOption], emptyTitle: String) {
+        self.identifier = identifier
+        self.isSubquery = isSubquery
+        self.collectionKey = collectionKey
+        self.modelKey = modelKey
+        self.options = options
+        self.emptyTitle = emptyTitle
+
+        // Computed property
+        self.selectedOptions = selectedOptions
+    }
+
+    func dictionaryRepresentation() -> WWDCFilterTypeDictionary {
+        var dictionary: WWDCFilterTypeDictionary = WWDCFilterTypeDictionary()
+
+        dictionary["options"] = options.dictionaryRepresentation()
+        dictionary["selectedOptions"] = selectedOptions.dictionaryRepresentation()
+
+        return dictionary
+    }
 }

--- a/WWDC/Preferences.swift
+++ b/WWDC/Preferences.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ThrowBack
+import SwiftyJSON
 
 extension Notification.Name {
     
@@ -65,6 +66,21 @@ final class Preferences {
         }
         set {
             defaults.set(newValue, forKey: #function)
+        }
+    }
+
+    var filtersState: JSON? {
+        get {
+            if let string = defaults.object(forKey: #function) as? String {
+                return JSON(parseJSON: string)
+            } else {
+                return nil
+            }
+        }
+        set {
+            if let myString = newValue?.rawString() {
+                defaults.set(myString, forKey: #function)
+            }
         }
     }
     

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -76,7 +76,7 @@ class SessionsTableViewController: NSViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     func selectSession(with identifier: String, scrollOnly: Bool = false) {
         guard let index = displayedRows.index(where: { row in
             guard case .session(let viewModel) = row.kind else { return false }

--- a/WWDC/TextualFilter.swift
+++ b/WWDC/TextualFilter.swift
@@ -48,5 +48,13 @@ struct TextualFilter: FilterType {
         
         return NSCompoundPredicate(orPredicateWithSubpredicates: subpredicates)
     }
-    
+
+    func dictionaryRepresentation() -> WWDCFilterTypeDictionary {
+        var dictionary: WWDCFilterTypeDictionary = WWDCFilterTypeDictionary()
+
+        dictionary["value"] = value
+
+        return dictionary
+    }
+
 }

--- a/WWDC/ToggleFilter.swift
+++ b/WWDC/ToggleFilter.swift
@@ -24,5 +24,13 @@ struct ToggleFilter: FilterType {
         
         return customPredicate
     }
-    
+
+    func dictionaryRepresentation() -> WWDCFilterTypeDictionary {
+        var dictionary: WWDCFilterTypeDictionary = WWDCFilterTypeDictionary()
+
+        dictionary["isOn"] = isOn
+
+        return dictionary
+    }
+
 }


### PR DESCRIPTION
I don't think this PR is ready, but I'm opening it to get some feedback. My implementation is simple in it's approach, yet effective. In ObjC I would've just encoded the object graphs by adopting the NSCoding protocol. But that isn't very Swifty and I didn't think it prudent to make all of the filter types objects.

Suggestions welcome. Nothing is too small.