### PR TITLE
Fixes PIP closes while filters are active

### DIFF
--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -158,7 +158,14 @@ final class SearchCoordinator {
             subpredicates.append(Session.videoPredicate)
         }
         
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
+        var predicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
+
+        if let appDelegate = NSApplication.shared().delegate as? AppDelegate,
+            let currentlyPlayingSession = appDelegate.coordinator.currentPlayerController?.sessionViewModel.session {
+
+            // Keep the currently playing video in the list to ensure PIP can re-select it if needed
+            predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicate, NSPredicate(format: "identifier == %@", currentlyPlayingSession.identifier)])
+        }
         
         #if DEBUG
             print(predicate)


### PR DESCRIPTION
The app behaves weirdly if you do the following:

1. Start playback
2. Enter PIP mode
3. Apply a filter to your list that excludes the currently playing session
4. Exit PIP mode

I fixed the issue by simply not filtering the current session, another fix would be from the player side by handling the case where the session isn't in the list and not allow PIP to exit or continue playback offscreen?