### PR TITLE
Excludes sessions that aren't tied to events on the schedule

### DIFF
--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -207,6 +207,7 @@ final class SearchCoordinator {
         
         if controller == scheduleController {
             subpredicates.append(NSPredicate(format: "ANY event.isCurrent == true"))
+            subpredicates.append(NSPredicate(format: "instances.@count > 0"))
         } else if controller == videosController {
             subpredicates.append(Session.videoPredicate)
         }


### PR DESCRIPTION
While playing with some other filtering stuff, I noticed that there were sessions that would show up in the "schedule" section only if you have a filter active. Apparently there are a few sessions/videos that didn't have scheduled events at WWDC.

A specific example is **2017-820: Express Yourself!**

This should bring the filtering in alignment with the initial list population, albeit from the reverse direction (the initial list is populated using sections, not sessions)