### PR TITLE
Resume using playbackSpeed.rawValue

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1331,11 +1331,7 @@ extension PUIPlayerView: PUITimelineViewDelegate {
     func timelineViewWillBeginInteractiveSeek() {
         wasPlayingBeforeStartingInteractiveSeek = isPlaying
         
-        if isPlayingExternally {
-            currentExternalPlaybackProvider?.pause()
-        } else {
-            player?.pause()
-        }
+        self.pause(nil)
     }
     
     func timelineViewDidSeek(to progress: Double) {
@@ -1353,11 +1349,7 @@ extension PUIPlayerView: PUITimelineViewDelegate {
     
     func timelineViewDidFinishInteractiveSeek() {
         if wasPlayingBeforeStartingInteractiveSeek {
-            if isPlayingExternally {
-                currentExternalPlaybackProvider?.play()
-            } else {
-                player?.play()
-            }
+            self.play(nil)
         }
     }
     


### PR DESCRIPTION
Fixes #265. Resumes by setting player rate to playbackSpeed.rawValue,
not player?.play(), which is equivalent to setting rate to 1.0.