### PR TITLE
Uses more appropriate switch case syntax

### DIFF
--- a/WWDC/FilterType.swift
+++ b/WWDC/FilterType.swift
@@ -37,18 +37,12 @@ extension Dictionary where Key == String, Value == [ String : Any ] {
             case .text:
                 //TextualFilter
                 self[filterID.rawValue] = filter.dictionaryRepresentation()
-            case .event:
-                fallthrough
-            case .focus:
-                fallthrough
-            case .track:
+
+            case .event, .focus, .track:
                 //MultipleChoiceFilter
                 self[filterID.rawValue] = filter.dictionaryRepresentation()
-            case .isFavorite:
-                fallthrough
-            case .isDownloaded:
-                fallthrough
-            case .isUnwatched:
+
+            case .isFavorite, .isDownloaded, .isUnwatched:
                 //ToggleFilters
                 self[filterID.rawValue] = filter.dictionaryRepresentation()
             }


### PR DESCRIPTION
This was the result of thinking like an objective-C developer, the Swift way is to simply specify all of the patterns that can match. Much less clutter.