### PR TITLE
Closing PiP no longer activates main window

### DIFF
--- a/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
+++ b/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
@@ -11,7 +11,7 @@ import Cocoa
 public protocol PUIPlayerViewDelegate: class {
     
     func playerViewWillEnterPictureInPictureMode(_ playerView: PUIPlayerView)
-    func playerViewWillExitPictureInPictureMode(_ playerView: PUIPlayerView)
+    func playerViewWillExitPictureInPictureMode(_ playerView: PUIPlayerView, isReturningFromPiP: Bool)
     func playerViewDidSelectAddAnnotation(_ playerView: PUIPlayerView, at timestamp: Double)
     func playerViewDidSelectToggleFullScreen(_ playerView: PUIPlayerView)
     

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1424,9 +1424,12 @@ extension PUIPlayerView: PIPViewControllerDelegate, PUIPictureContainerViewContr
     
     public func pipActionStop(_ pip: PIPViewController) {
         self.pause(pip)
+        delegate?.playerViewWillExitPictureInPictureMode(self, isReturningFromPiP: false)
     }
     
     public func pipActionReturn(_ pip: PIPViewController) {
+        delegate?.playerViewWillExitPictureInPictureMode(self, isReturningFromPiP: true)
+        
         if !NSApp.isActive {
             NSApp.activate(ignoringOtherApps: true)
         }
@@ -1458,8 +1461,6 @@ extension PUIPlayerView: PIPViewControllerDelegate, PUIPictureContainerViewContr
     }
     
     public func pipWillClose(_ pip: PIPViewController) {
-        delegate?.playerViewWillExitPictureInPictureMode(self)
-        
         pip.replacementRect = self.frame
         pip.replacementView = self
         pip.replacementWindow = self.lastKnownWindow

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1426,6 +1426,20 @@ extension PUIPlayerView: PIPViewControllerDelegate, PUIPictureContainerViewContr
         self.pause(pip)
     }
     
+    public func pipActionReturn(_ pip: PIPViewController) {
+        if !NSApp.isActive {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+        
+        if let window = self.lastKnownWindow {
+            window.makeKeyAndOrderFront(pip)
+            
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+        }
+    }
+    
     public func pipActionPause(_ pip: PIPViewController) {
         self.pause(pip)
     }
@@ -1445,18 +1459,6 @@ extension PUIPlayerView: PIPViewControllerDelegate, PUIPictureContainerViewContr
     
     public func pipWillClose(_ pip: PIPViewController) {
         delegate?.playerViewWillExitPictureInPictureMode(self)
-        
-        if !NSApp.isActive {
-            NSApp.activate(ignoringOtherApps: true)
-        }
-        
-        if let window = self.lastKnownWindow {
-            window.makeKeyAndOrderFront(pip)
-            
-            if window.isMiniaturized {
-                window.deminiaturize(nil)
-            }
-        }
         
         pip.replacementRect = self.frame
         pip.replacementView = self

--- a/WWDC/AppCoordinator+Shelf.swift
+++ b/WWDC/AppCoordinator+Shelf.swift
@@ -44,7 +44,7 @@ extension AppCoordinator: ShelfViewControllerDelegate {
         canRestorePlaybackContext = true
     }
     
-    func goBackToContextBeforePiP() {
+    func goBackToContextBeforePiP(_ isReturningFromPip: Bool) {
         isTransitioningPlayerContext = true
         defer { isTransitioningPlayerContext = false }
         
@@ -53,11 +53,13 @@ extension AppCoordinator: ShelfViewControllerDelegate {
         guard let identifier = playerOwnerSessionIdentifier else { return }
         guard let tab = playerOwnerTab else { return }
         
-        tabController.activeTab = tab
-        currentListController.selectSession(with: identifier)
+        if isReturningFromPip {
+            tabController.activeTab = tab
+            currentListController.selectSession(with: identifier)
+            currentPlayerController?.view.isHidden = false
+        }
         
         canRestorePlaybackContext = false
-        currentPlayerController?.view.isHidden = false
     }
     
     func shelfViewControllerDidSelectPlay(_ shelfController: ShelfViewController) {
@@ -85,8 +87,8 @@ extension AppCoordinator: ShelfViewControllerDelegate {
             
             if currentPlayerController == nil {
                 currentPlayerController = VideoPlayerViewController(player: playbackViewModel.player, session: viewModel)
-                currentPlayerController?.playerWillExitPictureInPicture = { [weak self] in
-                    self?.goBackToContextBeforePiP()
+                currentPlayerController?.playerWillExitPictureInPicture = { [weak self] isReturningFromPip in
+                    self?.goBackToContextBeforePiP(isReturningFromPip)
                 }
                 
                 currentPlayerController?.delegate = self

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -50,7 +50,7 @@ final class VideoPlayerViewController: NSViewController {
     
     var detached = false
     
-    var playerWillExitPictureInPicture: (() -> Void)?
+    var playerWillExitPictureInPicture: ((Bool) -> Void)?
     
     init(player: AVPlayer, session: SessionViewModel) {
         self.sessionViewModel = session
@@ -274,8 +274,8 @@ extension VideoPlayerViewController: PUIPlayerViewDelegate {
         playerView.snapshotPlayer(completion: completion)
     }
     
-    func playerViewWillExitPictureInPictureMode(_ playerView: PUIPlayerView) {
-        self.playerWillExitPictureInPicture?()
+    func playerViewWillExitPictureInPictureMode(_ playerView: PUIPlayerView, isReturningFromPiP: Bool) {
+        self.playerWillExitPictureInPicture?(isReturningFromPiP)
     }
     
     func playerViewWillEnterPictureInPictureMode(_ playerView: PUIPlayerView) {


### PR DESCRIPTION
Fixes #274. When using the stop button from PIP, the main window is
not de-miniaturised, does not become the active window, & the shelf selection does not revert to show the playing video.

As far as I can tell, this maintains any other existing behaviours.