### PR TITLE
Animate session table content changes, many selection fixes

### DIFF
--- a/WWDC/MultipleChoiceFilter.swift
+++ b/WWDC/MultipleChoiceFilter.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import SwiftyJSON
 
 struct FilterOption: Equatable {
     let title: String

--- a/WWDC/NSTableView+Rx.swift
+++ b/WWDC/NSTableView+Rx.swift
@@ -38,7 +38,7 @@ final class RxTableViewDelegateProxy: DelegateProxy, NSTableViewDelegate, Delega
     }
     
     func tableViewSelectionDidChange(_ notification: Notification) {
-        guard let numberOfRows = tableView?.numberOfRows, numberOfRows > 0 else { return }
+        guard let numberOfRows = tableView?.numberOfRows else { return }
         guard let selectedRow = tableView?.selectedRow else { return }
         
         let row: Int? = (selectedRow >= 0 && selectedRow < numberOfRows) ? selectedRow : nil

--- a/WWDC/SessionRow.swift
+++ b/WWDC/SessionRow.swift
@@ -33,7 +33,29 @@ final class SessionRow: NSObject {
         
         self.init(title: title)
     }
-    
+
+    override var debugDescription: String {
+        switch self.kind {
+        case .sectionHeader(let title):
+            return "Header: " + title
+        case .session(let viewModel):
+            return "Session: " + viewModel.identifier
+        }
+    }
+
+    // `hashValue` and `isEqual` both need to be provided to
+    // work correctly in sequences
+    override var hashValue: Int {
+        return diffIdentifier().hash
+    }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        if let diffable = object as? IGListDiffable {
+            return self.isEqual(toDiffableObject: diffable)
+        } else {
+            return false
+        }
+    }
 }
 
 extension SessionRow: IGListDiffable {

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -80,7 +80,10 @@ class ShelfViewController: NSViewController {
     private func updateBindings() {
         self.disposeBag = DisposeBag()
         
-        guard let viewModel = viewModel else { return }
+        guard let viewModel = viewModel else {
+            self.shelfView.image = nil
+            return
+        }
         
         viewModel.rxCanBePlayed.map({ !$0 }).bind(to: playButton.rx.isHidden).addDisposableTo(self.disposeBag)
         

--- a/WWDC/TrackColorView.swift
+++ b/WWDC/TrackColorView.swift
@@ -22,7 +22,6 @@ final class TrackColorView: NSView {
         super.init(frame: frameRect)
         
         wantsLayer = true
-        layer = WWDCLayer()
         
         layer?.cornerRadius = 2
         layer?.masksToBounds = true
@@ -78,5 +77,9 @@ final class TrackColorView: NSView {
         let progressFrame = NSRect(x: 0, y: 0, width: bounds.width, height: progressHeight)
         progressLayer.frame = progressFrame
     }
-    
+
+    override func makeBackingLayer() -> CALayer {
+        return WWDCLayer() as CALayer
+    }
+
 }

--- a/WWDC/WWDCImageView.swift
+++ b/WWDC/WWDCImageView.swift
@@ -86,7 +86,6 @@ class WWDCImageView: NSView {
     
     private func buildUI() {
         self.wantsLayer = true
-        self.layer = WWDCLayer()
         self.layer?.cornerRadius = 2
         self.layer?.masksToBounds = true
         
@@ -101,6 +100,10 @@ class WWDCImageView: NSView {
         super.layout()
         
         updateRoundness()
+    }
+
+    override func makeBackingLayer() -> CALayer {
+        return WWDCLayer() as CALayer
     }
     
     // MARK: - Editing


### PR DESCRIPTION
Since I rebased, this is a continuation of #287 .

Since I initially opened it, I fixed a few things.

1. The initial implementation didn't correctly handle the behavior when the **order** of the contents changed. It works now by reloading cells that are in both new and old results.
2. We now disallow empty selections, but I still needed to update the `SessionDetailsViewController` to have a null state to allow for the case when no results are found.
3. I've improved the selection preservation, again due to the order changing, the system can't correctly keep the selection preserved across updates.
4. When the table is updated, I scroll the list to ensure the first item in the selection is in the view. (this behavior might not be desired since the the whole thing feels a bit busy)

I'm having trouble with a bug that I don't think is directly caused by these changes. It may be made worse by my changes, however. I have a [video](https://www.dropbox.com/s/5nq4k8ns609zmnh/StrangeThumbnailBehavior.mov?dl=0) showing the behavior. Basically, the video shows the app launching, and then a couple of seconds later a call back happens that updates the list (with identical contents), but this results in all of the cells being reloaded. You see that several cell's have their images cleared. I tracked it down to `SessionTableCellView` line 85 getting a nil thumbnail, which in turn is being caused by the API returning a 403 error which I guess might be a rate limit? I could use a second set of eyes on it and I'm not sure if I have the time to learn the entire App API, etc to actually fix it.

Note: The order changing I'm referring to is the fact that in the schedule tab, items are sorted by date by default, but are sorted more like the videos tab if you apply a filter.