### PR TITLE
Avoid over iterating when filtering

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -125,19 +125,11 @@ public final class PUIPlayerView: NSView {
     }
 
     public var firstAnnotationBeforeCurrentTime: PUITimelineAnnotation? {
-        return annotations.filter({ annotation in
-            guard annotation.isValid else { return false }
-
-            return annotation.timestamp + 1 < currentTimestamp
-        }).last
+        return annotations.reversed().first { $0.isValid && $0.timestamp + 1 < currentTimestamp }
     }
 
     public var firstAnnotationAfterCurrentTime: PUITimelineAnnotation? {
-        return annotations.filter({ annotation in
-            guard annotation.isValid else { return false }
-
-            return annotation.timestamp > currentTimestamp + 1
-        }).first
+        return annotations.first { $0.isValid && $0.timestamp > currentTimestamp + 1 }
     }
 
     public func seek(to annotation: PUITimelineAnnotation) {
@@ -1282,7 +1274,7 @@ public final class PUIPlayerView: NSView {
 
         unhighlightExternalPlaybackButtons()
 
-        guard let registration = externalPlaybackProviders.filter({ type(of: $0.provider).name == currentProviderName }).first else { return }
+        guard let registration = externalPlaybackProviders.first(where: { type(of: $0.provider).name == currentProviderName }) else { return }
 
         registration.button.tintColor = .playerHighlight
 

--- a/PlayerUI/Views/PUIPlayerWindow.swift
+++ b/PlayerUI/Views/PUIPlayerWindow.swift
@@ -52,9 +52,9 @@ open class PUIPlayerWindow: NSWindow {
         guard _storedTitlebarView == nil else { return _storedTitlebarView }
         guard let containerClass = NSClassFromString("NSTitlebarContainerView") else { return nil }
 
-        guard let containerView = contentView?.superview?.subviews.filter({ $0.isKind(of: containerClass) }).last else { return nil }
+        guard let containerView = contentView?.superview?.subviews.reversed().first(where: { $0.isKind(of: containerClass) }) else { return nil }
 
-        guard let titlebar = containerView.subviews.filter({ $0.isKind(of: NSVisualEffectView.self) }).last as? NSVisualEffectView else { return nil }
+        guard let titlebar = containerView.subviews.reversed().first(where: { $0.isKind(of: NSVisualEffectView.self) }) as? NSVisualEffectView else { return nil }
 
         _storedTitlebarView = titlebar
 

--- a/WWDC/DownloadManager.swift
+++ b/WWDC/DownloadManager.swift
@@ -143,11 +143,7 @@ final class DownloadManager: NSObject {
     }
 
     func isDownloading(_ url: String) -> Bool {
-        let downloading = downloadTasks.keys.filter { taskURL in
-            return url == taskURL
-        }
-
-        return (downloading.count > 0)
+        return downloadTasks.keys.contains { $0 == url }
     }
 
     func localVideoPath(_ remoteURL: String) -> String? {

--- a/WWDC/ImageDownloadCenter.swift
+++ b/WWDC/ImageDownloadCenter.swift
@@ -47,11 +47,11 @@ final class ImageDownloadCenter {
     }
 
     func hasActiveOperation(for url: URL) -> Bool {
-        return queue.operations.filter { op in
+        return queue.operations.contains { op in
             guard let op = op as? ImageDownloadOperation else { return false }
 
             return op.url == url && op.isExecuting
-            }.count > 0
+        }
     }
 
 }

--- a/WWDC/WWDCTabViewController.swift
+++ b/WWDC/WWDCTabViewController.swift
@@ -110,7 +110,7 @@ class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Ta
     }
 
     private func tabItem(with identifier: String) -> NSTabViewItem? {
-        return tabViewItems.filter({ $0.identifier as? String == identifier }).first
+        return tabViewItems.first { $0.identifier as? String == identifier }
     }
 
     override func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: String, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {

--- a/WWDC/WWDCWindow.swift
+++ b/WWDC/WWDCWindow.swift
@@ -31,9 +31,9 @@ class WWDCWindow: NSWindow {
         guard _storedTitlebarView == nil else { return _storedTitlebarView }
         guard let containerClass = NSClassFromString("NSTitlebarContainerView") else { return nil }
 
-        guard let containerView = contentView?.superview?.subviews.filter({ $0.isKind(of: containerClass) }).last else { return nil }
+        guard let containerView = contentView?.superview?.subviews.reversed().first(where: { $0.isKind(of: containerClass) }) else { return nil }
 
-        guard let titlebar = containerView.subviews.filter({ $0.isKind(of: NSVisualEffectView.self) }).last as? NSVisualEffectView else { return nil }
+        guard let titlebar = containerView.subviews.reversed().first(where: { $0.isKind(of: NSVisualEffectView.self) }) as? NSVisualEffectView else { return nil }
 
         _storedTitlebarView = titlebar
 


### PR DESCRIPTION
Use array.first(where:) instead of array.filter().first
Use array.contains(where:) instead filtering and checking for filtered array size
Use array.reversed().first(where:) instead of array.filter().last