### PR TITLE
Fix #307 by improving equality checking of FilterOption

### DIFF
--- a/WWDC/MultipleChoiceFilter.swift
+++ b/WWDC/MultipleChoiceFilter.swift
@@ -24,7 +24,7 @@ struct FilterOption: Equatable {
     }
 
     static func ==(lhs: FilterOption, rhs: FilterOption) -> Bool {
-        return lhs.value == rhs.value && lhs.title == rhs.title && lhs.isNegative == rhs.isNegative
+        return lhs.value == rhs.value && lhs.isNegative == rhs.isNegative && lhs.title == rhs.title
     }
 
     func dictionaryRepresentation() -> [String : String] {

--- a/WWDC/MultipleChoiceFilter.swift
+++ b/WWDC/MultipleChoiceFilter.swift
@@ -24,7 +24,7 @@ struct FilterOption: Equatable {
     }
 
     static func ==(lhs: FilterOption, rhs: FilterOption) -> Bool {
-        return lhs.value == rhs.value
+        return lhs.value == rhs.value && lhs.title == rhs.title && lhs.isNegative == rhs.isNegative
     }
 
     func dictionaryRepresentation() -> [String : String] {


### PR DESCRIPTION
The equality checking function is used by `contains`. Specifically, the problem was manifested in `SearchFiltersViewController` line 238 when determining whether to place a checkmark next to a filter.