### PR TITLE
Partially addresses issue #305

### DIFF
--- a/WWDC/FilterType.swift
+++ b/WWDC/FilterType.swift
@@ -46,9 +46,29 @@ extension Dictionary where Key == String, Value == [ String : Any ] {
                 //ToggleFilters
                 self[filterID.rawValue] = filter.dictionaryRepresentation()
             }
+        }
+    }
+}
 
+extension Array where Element == FilterType {
+
+    func isIdentical(to otherArray: [Element]) -> Bool {
+
+        var isIdentical = false
+
+        if self.count == otherArray.count {
+
+            isIdentical = true
+
+            for filter in self {
+
+                if !otherArray.contains(where: { $0.identifier == filter.identifier }) {
+                    isIdentical = false
+                    break
+                }
+            }
         }
 
+        return isIdentical
     }
-
 }

--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -130,11 +130,13 @@ final class SearchCoordinator {
                                                    scheduleDownloadedFilter,
                                                    scheduleUnwatchedFilter]
 
-        scheduleSearchController.filters = scheduleSearchFilters
+        if !scheduleSearchController.filters.isIdentical(to: scheduleSearchFilters) {
+            scheduleSearchController.filters = scheduleSearchFilters
 
-        let activeScheduleFilters = scheduleSearchFilters.filter { !$0.isEmpty }
-        if activeScheduleFilters.count > 0 {
-            updateSearchResults(for: scheduleController, with: activeScheduleFilters)
+            let activeScheduleFilters = scheduleSearchFilters.filter { !$0.isEmpty }
+            if activeScheduleFilters.count > 0 {
+                updateSearchResults(for: scheduleController, with: activeScheduleFilters)
+            }
         }
 
         // Videos Filter Configuration
@@ -176,11 +178,13 @@ final class SearchCoordinator {
                                                  videosDownloadedFilter,
                                                  videosUnwatchedFilter]
 
-        videosSearchController.filters = videosSearchFilters
+        if !videosSearchController.filters.isIdentical(to: videosSearchFilters) {
+            videosSearchController.filters = videosSearchFilters
 
-        let activeVideosFilters = videosSearchFilters.filter { !$0.isEmpty }
-        if activeVideosFilters.count > 0 {
-            updateSearchResults(for: videosController, with: activeVideosFilters)
+            let activeVideosFilters = videosSearchFilters.filter { !$0.isEmpty }
+            if activeVideosFilters.count > 0 {
+                updateSearchResults(for: videosController, with: activeVideosFilters)
+            }
         }
 
         // set delegates

--- a/WWDC/SearchFiltersViewController.swift
+++ b/WWDC/SearchFiltersViewController.swift
@@ -61,21 +61,6 @@ final class SearchFiltersViewController: NSViewController {
     var filters: [FilterType] {
         set {
 
-            if newValue.count == effectiveFilters.count {
-                var newFiltersAreIdentical = true
-                for filter in newValue {
-
-                    if !effectiveFilters.contains(where: { $0.identifier == filter.identifier }) {
-                        newFiltersAreIdentical = false
-                        break
-                    }
-                }
-
-                if newFiltersAreIdentical {
-                    return
-                }
-            }
-
             effectiveFilters = newValue
 
             updateUI()

--- a/WWDC/SearchFiltersViewController.swift
+++ b/WWDC/SearchFiltersViewController.swift
@@ -60,6 +60,22 @@ final class SearchFiltersViewController: NSViewController {
 
     var filters: [FilterType] {
         set {
+
+            if newValue.count == effectiveFilters.count {
+                var newFiltersAreIdentical = true
+                for filter in newValue {
+
+                    if !effectiveFilters.contains(where: { $0.identifier == filter.identifier }) {
+                        newFiltersAreIdentical = false
+                        break
+                    }
+                }
+
+                if newFiltersAreIdentical {
+                    return
+                }
+            }
+
             effectiveFilters = newValue
 
             updateUI()

--- a/WWDC/SessionRow.swift
+++ b/WWDC/SessionRow.swift
@@ -39,7 +39,7 @@ final class SessionRow: NSObject {
         case .sectionHeader(let title):
             return "Header: " + title
         case .session(let viewModel):
-            return "Session: " + viewModel.identifier
+            return "Session: " + viewModel.identifier + " " + viewModel.title
         }
     }
 

--- a/WWDC/SessionTableCellView.swift
+++ b/WWDC/SessionTableCellView.swift
@@ -20,9 +20,11 @@ final class SessionTableCellView: NSTableCellView {
 
             disposeBag = DisposeBag()
 
-            thumbnailImageView.image = #imageLiteral(resourceName: "noimage")
+            DispatchQueue.main.async {
+                self.thumbnailImageView.image = #imageLiteral(resourceName: "noimage")
 
-            bindUI()
+                self.bindUI()
+            }
         }
     }
 


### PR DESCRIPTION
This is the result of investigating #305. There are lot of moving parts during the app launch, and some duplicated/unnecessary calls that result in updating the search results multiple times.

1. `SearchCooridinator.configureFilters()` was/is getting called multiple times. The initial call is due the "offline" call, and the second call is in response to the synchronization callback. This may be related to #306, but I'm not sure.
2. `AppCooridinator.doUpdateLists()` was/is getting called multiple times. Same reason as 1

In this branch I addressed both of these defensively, which is less than ideal but may be required.

For case 1, in `SearchCooridinator`, I put checks in place to see if the "new" filter options are different than what is already configured on the controller. If they are the same, I do nothing. This was the quick approach as I can't be sure if there would be side effects if I enforced a "call once" policy on this method.

For case 2, in `SessionTableViewController`, I put checks in place to detect if the "new" array of sessions is identical to the old array (in content and in order), and if they are I simply don't do anything. The lack of this check was what was causing the weird scrolling after the user has scrolled. Basically, the list gets setup then the synchronization callback results in an update with identical values (accept in the case the the synchronization with the server might actually change some values).

Additionally, I noticed some major performance issues arising from the the code to update the table. I tracked most of it down to `SessionTableCellView` doing too much work synchronously in response to setting the `viewModel` property. Dispatching that asynchronously reduced noticeable UI delay when updating the filters considerably, it also **improves general scrolling performance 🎉**. You'll notice the thumbnails getting set **after** the row scrolls onto screen rather than before.

The other portion of delay was being caused by set operations, especially in the case when the old set and new set are both fairly large. I pushed everything onto the background to address that delay (0.1~0.4 seconds), but optimizing the looping logic might prove to be a better long term solution for that. As it stands, each loop is O(n^2) worst case since I call `index(of:)` for each element, and they might be the same elements.