### PR TITLE
Increase contrast in the search field if the matching accessibility feature is turned on.

### DIFF
--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		012BEFA41EE8658F007E72CA /* EventKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 012BEFA31EE8658F007E72CA /* EventKit.framework */; };
 		01B3EB4A1EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3EB491EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift */; };
+		6834F3771F6D227E004BB419 /* WWDCSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6834F3761F6D227E004BB419 /* WWDCSearchField.swift */; };
 		DD0159A71ECFE26200F980F1 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A61ECFE26200F980F1 /* DeepLink.swift */; };
 		DD0159A91ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */; };
 		DD0159CF1ED0CD3A00F980F1 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159CE1ED0CD3A00F980F1 /* PreferencesWindowController.swift */; };
@@ -359,6 +360,7 @@
 /* Begin PBXFileReference section */
 		012BEFA31EE8658F007E72CA /* EventKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EventKit.framework; path = System/Library/Frameworks/EventKit.framework; sourceTree = SDKROOT; };
 		01B3EB491EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+SessionTableViewContextMenuActions.swift"; sourceTree = "<group>"; };
+		6834F3761F6D227E004BB419 /* WWDCSearchField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WWDCSearchField.swift; sourceTree = "<group>"; };
 		DD0159A61ECFE26200F980F1 /* DeepLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+Bookmarks.swift"; sourceTree = "<group>"; };
 		DD0159CE1ED0CD3A00F980F1 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 				DDC678181EDB2CD300A4E19C /* ActionLabel.swift */,
 				DD6E06F31EDBC11F000EAEA4 /* WWDCTextButton.swift */,
 				DD6E06F51EDBC379000EAEA4 /* WWDCBottomBorderView.swift */,
+				6834F3761F6D227E004BB419 /* WWDCSearchField.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1879,6 +1882,7 @@
 				DD7F386F1EABF631002D8C00 /* NSTableView+IGListKit.swift in Sources */,
 				DD382B7E1EAC3565009760C4 /* TabItemView.swift in Sources */,
 				DD382B7B1EAC345F009760C4 /* MaskImageView.m in Sources */,
+				6834F3771F6D227E004BB419 /* WWDCSearchField.swift in Sources */,
 				DDCE7ECD1EA7A0F800C7A3CA /* MainWindowController.swift in Sources */,
 				DDC6780F1EDB253D00A4E19C /* AboutWindowController.swift in Sources */,
 				01B3EB4A1EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift in Sources */,

--- a/WWDC/Base.lproj/Main.storyboard
+++ b/WWDC/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="17A344b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
@@ -632,7 +632,7 @@
                                             <stackView distribution="fillProportionally" orientation="horizontal" alignment="bottom" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qTs-9y-MbZ">
                                                 <rect key="frame" x="12" y="116" width="319" height="25"/>
                                                 <subviews>
-                                                    <searchField wantsLayer="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="NO" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fla-Ig-nku">
+                                                    <searchField wantsLayer="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="NO" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fla-Ig-nku" customClass="WWDCSearchField" customModule="WWDC" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="228" height="22"/>
                                                         <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="mC0-Jx-M3e">
                                                             <font key="font" metaFont="system"/>
@@ -715,7 +715,7 @@
                                                 </connections>
                                             </popUpButton>
                                             <segmentedControl horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Teg-LY-Sf3" customClass="WWDCSegmentedControl" customModule="WWDC" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="10" width="323" height="21"/>
+                                                <rect key="frame" x="10" y="10" width="323" height="20"/>
                                                 <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectAny" id="0Zl-mA-eiw">
                                                     <font key="font" metaFont="smallSystem"/>
                                                     <segments>

--- a/WWDC/SearchFiltersViewController.swift
+++ b/WWDC/SearchFiltersViewController.swift
@@ -133,45 +133,9 @@ final class SearchFiltersViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        accessibilityOptionsChanged(nil)
-
-        NotificationCenter.default.addObserver(self, selector: #selector(self.accessibilityOptionsChanged), name: Notification.Name.NSWorkspaceAccessibilityDisplayOptionsDidChange, object: nil)
-
         setFilters(hidden: true)
 
         updateUI()
-    }
-
-    override func viewWillDisappear() {
-        NotificationCenter.default.removeObserver(self, name: Notification.Name.NSWorkspaceAccessibilityDisplayOptionsDidChange, object: nil)
-    }
-
-    // Taken from https://stackoverflow.com/a/25952895
-
-    func tintedImage(_ image: NSImage, tint: NSColor) -> NSImage {
-        guard let tinted = image.copy() as? NSImage else { return image }
-        tinted.lockFocus()
-        tint.set()
-
-        let imageRect = NSRect(origin: NSZeroPoint, size: image.size)
-        NSRectFillUsingOperation(imageRect, .sourceAtop)
-
-        tinted.unlockFocus()
-        return tinted
-    }
-
-    func accessibilityOptionsChanged(_: Notification?) {
-        if NSWorkspace.shared().accessibilityDisplayShouldIncreaseContrast {
-            searchField.textColor = NSColor.white
-        } else {
-            searchField.textColor = NSColor.textColor
-        }
-
-        if let cell = (searchField.cell as? NSSearchFieldCell)?.searchButtonCell {
-            if let image = cell.image {
-                cell.image = tintedImage(image, tint: searchField.textColor!)
-            }
-        }
     }
 
     func setFilters(hidden: Bool) {

--- a/WWDC/WWDCSearchField.swift
+++ b/WWDC/WWDCSearchField.swift
@@ -1,0 +1,70 @@
+//
+//  WWDCSearchField.swift
+//  WWDC
+//
+//  Created by Alessandro Gatti on 16/09/2017.
+//  Copyright © 2017 Guilherme Rambo. All rights reserved.
+//
+
+import Cocoa
+
+class WWDCSearchField : NSSearchField {
+
+    private var isObservingAccessibilityState : Bool = false
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+
+        if (newWindow != nil) {
+            // Update the view state from the current accessibility settings too
+
+            accessibilityOptionsChanged(nil)
+
+            startObservingAccessibilityOptionChanges()
+        } else {
+            stopObservingAccessibilityOptionChanges()
+        }
+    }
+
+    private func startObservingAccessibilityOptionChanges() {
+        if (!isObservingAccessibilityState) {
+            NotificationCenter.default.addObserver(self, selector: #selector(self.accessibilityOptionsChanged), name: Notification.Name.NSWorkspaceAccessibilityDisplayOptionsDidChange, object: nil)
+            isObservingAccessibilityState = true
+        }
+    }
+
+    private func stopObservingAccessibilityOptionChanges() {
+        if (isObservingAccessibilityState) {
+            NotificationCenter.default.removeObserver(self, name: Notification.Name.NSWorkspaceAccessibilityDisplayOptionsDidChange, object: nil)
+            isObservingAccessibilityState = false
+        }
+    }
+
+    @objc private func accessibilityOptionsChanged(_: Notification?) {
+        if NSWorkspace.shared().accessibilityDisplayShouldIncreaseContrast {
+            self.textColor = NSColor.white
+        } else {
+            self.textColor = NSColor.controlTextColor
+        }
+
+        if let cell = (cell as? NSSearchFieldCell)?.searchButtonCell {
+            if let image = cell.image {
+                cell.image = tintedImage(image, tint: self.textColor!)
+            }
+        }
+    }
+
+    // Taken from https://stackoverflow.com/a/25952895
+
+    private func tintedImage(_ image: NSImage, tint: NSColor) -> NSImage {
+        guard let tinted = image.copy() as? NSImage else { return image }
+        tinted.lockFocus()
+        tint.set()
+
+        let imageRect = NSRect(origin: NSZeroPoint, size: image.size)
+        NSRectFillUsingOperation(imageRect, .sourceAtop)
+
+        tinted.unlockFocus()
+        return tinted
+    }
+}


### PR DESCRIPTION
If "Increase contrast" is turned on in the accessibility settings, macOS will use a darker shade of gray for text fields, assuming that the background is set to a light colour.  However, since WWDC uses a dark background, the text field becomes pretty much unreadable:

![before_patch](https://user-images.githubusercontent.com/235740/30462159-70e4924e-99f6-11e7-97be-75c9f841fdd7.png)

After this patch the same control looks as such:

![after_patch](https://user-images.githubusercontent.com/235740/30462174-8238907c-99f6-11e7-9451-862be0def7b8.png)

The patch also makes the application listen for accessibility state changes and change the text colour accordingly.

Technically speaking, all of this may be sidestepped by just forcing the NSSearchField to always display using NSColor.white (or an appropriate light colour), but maybe that is not desirable.