### PR TITLE
Fix debug console warnings when using Swift 3 Objective-C Inference Mode

### DIFF
--- a/WWDC/TabItemView.swift
+++ b/WWDC/TabItemView.swift
@@ -29,8 +29,8 @@ extension NSStackView {
 
 final class TabItemView: NSView {
 
-    var target: Any?
-    var action: Selector?
+    @objc var target: Any?
+    @objc var action: Selector?
 
     var controllerIdentifier: String = ""
 

--- a/WWDC/WWDCImageView.swift
+++ b/WWDC/WWDCImageView.swift
@@ -48,7 +48,7 @@ class WWDCImageView: NSView {
         }
     }
 
-    var isEditable: Bool = false {
+    @objc var isEditable: Bool = false {
         didSet {
             if isEditable {
                 registerForDraggedTypes([NSURLPboardType, NSFilenamesPboardType])


### PR DESCRIPTION
This fix the tab not working but I chose to not disable inference yet, I will try to find more cases where is needed to use the `@objc` keyword.

