### PR TITLE
Display session or lab day & time during event period

### DIFF
--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -210,7 +210,7 @@ final class SessionViewModel: NSObject {
 
         var result = "\(event.name) · Session \(session.number)"
 
-        if let date = session.instances.first?.startTime {
+        if (event.startDate...event.endDate).contains(Date()), let date = session.instances.first?.startTime {
             result += " · " + standardFormatted(date: date, withTimeZoneName: false)
         }
 

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -204,20 +204,22 @@ final class SessionViewModel: NSObject {
     static func footer(for session: Session, at event: ConfCore.Event?) -> String {
         guard let event = event else { return "" }
 
-        let eventName = event.name
-
         let focusesArray = session.focuses.toArray()
 
         let allFocuses = SessionViewModel.focusesDescription(from: focusesArray, collapse: false)
 
-        var result = "\(eventName) · Session \(session.number)"
+        var result = "\(event.name) · Session \(session.number)"
+
+        if let date = session.instances.first?.startTime {
+            result += " · " + standardFormatted(date: date, withTimeZoneName: false)
+        }
+
+        if session.mediaDuration > 0, let duration = String(timestamp: session.mediaDuration) {
+            result += " · " + duration
+        }
 
         if focusesArray.count > 0 {
             result += " · \(allFocuses)"
-        }
-        
-        if session.mediaDuration > 0, let duration = String(timestamp: session.mediaDuration) {
-            result += " · " + duration
         }
 
         return result


### PR DESCRIPTION
Fixes #222, displaying session times during WWDC week only. Also re-orders the footer slightly, with the intention of keeping related information together.

**Example**
<img width="473" alt="screen shot 2017-10-15 at 23 03 53" src="https://user-images.githubusercontent.com/11646957/31589667-4abb1628-b1fd-11e7-866f-dd735d602ca5.png">
