### PR TITLE
Replaced 'addDisposableTo' with 'disposed(by:)'

### DIFF
--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -137,17 +137,17 @@ final class AppCoordinator {
             self?.activeTab = activeTab
 
             self?.updateSelectedViewModelRegardlessOfTab()
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         selectedSession.subscribeOn(MainScheduler.instance).subscribe(onNext: { [weak self] viewModel in
             self?.videosController.detailViewController.viewModel = viewModel
             self?.updateSelectedViewModelRegardlessOfTab()
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         selectedScheduleItem.subscribeOn(MainScheduler.instance).subscribe(onNext: { [weak self] viewModel in
             self?.scheduleController.detailViewController.viewModel = viewModel
             self?.updateSelectedViewModelRegardlessOfTab()
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
     }
 
     private func updateSelectedViewModelRegardlessOfTab() {
@@ -195,13 +195,17 @@ final class AppCoordinator {
             tabController.hideLoading()
         }
 
-        storage.tracksObservable.subscribe(onNext: { [weak self] tracks in
-            self?.videosController.listViewController.tracks = tracks
-        }).dispose()
+        storage.tracksObservable
+            .take(1)
+            .subscribe(onNext: { [weak self] tracks in
+                self?.videosController.listViewController.tracks = tracks
+            }).disposed(by: disposeBag)
 
-        storage.scheduleObservable.subscribe(onNext: { [weak self] sections in
-            self?.scheduleController.listViewController.scheduleSections = sections
-        }).dispose()
+        storage.scheduleObservable
+            .take(1)
+            .subscribe(onNext: { [weak self] sections in
+                self?.scheduleController.listViewController.scheduleSections = sections
+            }).disposed(by: disposeBag)
 
         liveObserver.start()
 

--- a/WWDC/BookmarkViewController.swift
+++ b/WWDC/BookmarkViewController.swift
@@ -125,7 +125,7 @@ final class BookmarkViewController: NSViewController {
             guard let bookmark = self?.bookmark else { return }
             
             self?.storage.modify(bookmark) { $0.body = text }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
     }
 
 }

--- a/WWDC/PreferencesCoordinator.swift
+++ b/WWDC/PreferencesCoordinator.swift
@@ -61,11 +61,11 @@ final class PreferencesCoordinator {
         #if ICLOUD
             CMSCommunityCenter.shared.accountStatus.observeOn(MainScheduler.instance).subscribe(onNext: { [weak self] status in
                 self?.accountController.cloudAccountIsAvailable = (status == .available)
-            }).addDisposableTo(disposeBag)
+            }).disposed(by: disposeBag)
 
             CMSCommunityCenter.shared.userProfile.observeOn(MainScheduler.instance).subscribe(onNext: { [weak self] profile in
                 self?.accountController.profile = profile
-            }).addDisposableTo(disposeBag)
+            }).disposed(by: disposeBag)
         #endif
     }
 

--- a/WWDC/SessionActionsViewController.swift
+++ b/WWDC/SessionActionsViewController.swift
@@ -156,7 +156,7 @@ class SessionActionsViewController: NSViewController {
             } else {
                 self?.favoriteButton.toolTip = "Add to favorites"
             }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         if let rxDownloadState = DownloadManager.shared.downloadStatusObservable(for: viewModel.session) {
             rxDownloadState.throttle(0.8, scheduler: MainScheduler.instance).subscribe(onNext: { [weak self] status in
@@ -183,7 +183,7 @@ class SessionActionsViewController: NSViewController {
                     self?.downloadButton.image = #imageLiteral(resourceName: "trash")
                     self?.downloadButton.action = #selector(SessionActionsViewController.deleteDownload)
                 }
-            }).addDisposableTo(disposeBag)
+            }).disposed(by: disposeBag)
         } else {
             // session can't be downloaded (maybe Lab or download not available yet)
             downloadIndicator.isHidden = true

--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -126,9 +126,9 @@ class SessionSummaryViewController: NSViewController {
 
         viewModel.rxTitle.map(NSAttributedString.attributedBoldTitle(with:)).subscribe(onNext: { [weak self] title in
             self?.titleLabel.attributedStringValue = title
-        }).addDisposableTo(disposeBag)
-        viewModel.rxSummary.bind(to: summaryLabel.rx.text).addDisposableTo(disposeBag)
-        viewModel.rxFooter.bind(to: contextLabel.rx.text).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
+        viewModel.rxSummary.bind(to: summaryLabel.rx.text).disposed(by: disposeBag)
+        viewModel.rxFooter.bind(to: contextLabel.rx.text).disposed(by: disposeBag)
     }
 
 }

--- a/WWDC/SessionTableCellView.swift
+++ b/WWDC/SessionTableCellView.swift
@@ -52,17 +52,17 @@ final class SessionTableCellView: NSTableCellView {
 
         guard let viewModel = viewModel else { return }
 
-        viewModel.rxTitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(titleLabel.rx.text).addDisposableTo(disposeBag)
-        viewModel.rxSubtitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(subtitleLabel.rx.text).addDisposableTo(disposeBag)
-        viewModel.rxContext.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(contextLabel.rx.text).addDisposableTo(disposeBag)
+        viewModel.rxTitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(titleLabel.rx.text).disposed(by: disposeBag)
+        viewModel.rxSubtitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(subtitleLabel.rx.text).disposed(by: disposeBag)
+        viewModel.rxContext.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(contextLabel.rx.text).disposed(by: disposeBag)
 
-        viewModel.rxIsFavorite.distinctUntilChanged().map({ !$0 }).bind(to: favoritedImageView.rx.isHidden).addDisposableTo(disposeBag)
-        viewModel.rxIsDownloaded.distinctUntilChanged().map({ !$0 }).bind(to: downloadedImageView.rx.isHidden).addDisposableTo(disposeBag)
+        viewModel.rxIsFavorite.distinctUntilChanged().map({ !$0 }).bind(to: favoritedImageView.rx.isHidden).disposed(by: disposeBag)
+        viewModel.rxIsDownloaded.distinctUntilChanged().map({ !$0 }).bind(to: downloadedImageView.rx.isHidden).disposed(by: disposeBag)
 
         let isSnowFlake = Observable.zip(viewModel.rxIsCurrentlyLive, viewModel.rxIsLab)
 
-        isSnowFlake.map({ !$0.0 && !$0.1 }).bind(to: snowFlakeView.rx.isHidden).addDisposableTo(disposeBag)
-        isSnowFlake.map({ $0.0 || $0.1 }).bind(to: thumbnailImageView.rx.isHidden).addDisposableTo(disposeBag)
+        isSnowFlake.map({ !$0.0 && !$0.1 }).bind(to: snowFlakeView.rx.isHidden).disposed(by: disposeBag)
+        isSnowFlake.map({ $0.0 || $0.1 }).bind(to: thumbnailImageView.rx.isHidden).disposed(by: disposeBag)
 
         isSnowFlake.subscribe(onNext: { [weak self] (isLive: Bool, isLab: Bool) -> Void in
             if isLive {
@@ -70,7 +70,7 @@ final class SessionTableCellView: NSTableCellView {
             } else if isLab {
                 self?.snowFlakeView.image = #imageLiteral(resourceName: "lab-indicator")
             }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         viewModel.rxImageUrl.distinctUntilChanged({ $0 != $1 }).subscribe(onNext: { [weak self] imageUrl in
             guard let imageUrl = imageUrl else { return }
@@ -82,15 +82,15 @@ final class SessionTableCellView: NSTableCellView {
 
                 self?.thumbnailImageView.image = thumb
             }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         viewModel.rxColor.distinctUntilChanged({ $0 == $1 }).subscribe(onNext: { [weak self] color in
             self?.contextColorView.color = color
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         viewModel.rxDarkColor.distinctUntilChanged({ $0 == $1 }).subscribe(onNext: { [weak self] color in
             self?.snowFlakeView.backgroundColor = color
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         viewModel.rxProgresses.subscribe(onNext: { [weak self] progresses in
             if let progress = progresses.first {
@@ -100,7 +100,7 @@ final class SessionTableCellView: NSTableCellView {
                 self?.contextColorView.hasValidProgress = false
                 self?.contextColorView.progress = 0
             }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
 
         viewModel.rxSessionType.distinctUntilChanged().subscribe(onNext: { [weak self] type in
             guard type != .session && type != .lab else { return }
@@ -111,7 +111,7 @@ final class SessionTableCellView: NSTableCellView {
             default:
                 self?.thumbnailImageView.image = #imageLiteral(resourceName: "special")
             }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
     }
 
     private lazy var titleLabel: NSTextField = {

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -414,7 +414,7 @@ class SessionsTableViewController: NSViewController {
             guard case .session(let viewModel) = self.displayedRows[index].kind else { return nil }
 
             return viewModel
-            }.bind(to: selectedSession).addDisposableTo(disposeBag)
+            }.bind(to: selectedSession).disposed(by: disposeBag)
     }
 
     // MARK: - Contextual menu

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -85,7 +85,7 @@ class ShelfViewController: NSViewController {
             return
         }
 
-        viewModel.rxCanBePlayed.map({ !$0 }).bind(to: playButton.rx.isHidden).addDisposableTo(disposeBag)
+        viewModel.rxCanBePlayed.map({ !$0 }).bind(to: playButton.rx.isHidden).disposed(by: disposeBag)
 
         viewModel.rxImageUrl.subscribe(onNext: { [weak self] imageUrl in
             self?.currentImageDownloadOperation?.cancel()
@@ -101,7 +101,7 @@ class ShelfViewController: NSViewController {
 
                 self?.shelfView.image = original
             }
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
     }
 
     @objc private func play(_ sender: Any?) {

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -164,7 +164,7 @@ final class VideoPlayerViewController: NSViewController {
         let bookmarks = sessionViewModel.session.bookmarks.sorted(byKeyPath: "timecode")
         Observable.collection(from: bookmarks).observeOn(MainScheduler.instance).subscribe(onNext: { [weak self] bookmarks in
             self?.playerView.annotations = bookmarks.toArray()
-        }).addDisposableTo(disposeBag)
+        }).disposed(by: disposeBag)
     }
 
     @objc private func annotationSelected(notification: Notification) {


### PR DESCRIPTION
* Replaced `addDisposableTo` with `disposed(by:)`, because the former is deprecated

* Fixed small RxSwift API issue

In the following code block `onNext` is not guaranteed to be executed.
Also, explicit use of `dispose` is discourage AFAIK.
```
storage.tracksObservable.subscribe(onNext: { [weak self] tracks in
    self?.videosController.listViewController.tracks = tracks
}).dispose()
```

It is better to do it explicitly.
```
storage.tracksObservable
    .take(1)
    .subscribe(onNext: { [weak self] tracks in
        self?.videosController.listViewController.tracks = tracks
    }).disposed(by: disposeBag)
```

What is the place of RxSwift in the project? Maybe you want to constraint it to the core logic or UI?
