### PR TITLE
Reduce verbosity by using dot syntax

### DIFF
--- a/PlayerUI/Controllers/PUIAnnotationWindowController.swift
+++ b/PlayerUI/Controllers/PUIAnnotationWindowController.swift
@@ -16,7 +16,7 @@ class PUIAnnotationWindowController: NSWindowController {
     }
 
     init() {
-        let window = PUIAnnotationWindow(contentRect: Metrics.defaultRect, styleMask: [NSWindow.StyleMask.borderless], backing: .buffered, defer: false)
+        let window = PUIAnnotationWindow(contentRect: Metrics.defaultRect, styleMask: .borderless, backing: .buffered, defer: false)
 
         super.init(window: window)
 
@@ -33,7 +33,7 @@ class PUIAnnotationWindowController: NSWindowController {
         v.state = .active
         v.blendingMode = .behindWindow
         v.material = .dark
-        v.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+        v.appearance = NSAppearance(named: .vibrantDark)
         v.maskImage = self.maskImage(with: Metrics.cornerRadius)
 
         return v

--- a/PlayerUI/Controllers/PUIExternalPlaybackStatusViewController.swift
+++ b/PlayerUI/Controllers/PUIExternalPlaybackStatusViewController.swift
@@ -51,7 +51,7 @@ class PUIExternalPlaybackStatusViewController: NSViewController {
     private lazy var titleLabel: NSTextField = {
         let f = NSTextField(labelWithString: "")
 
-        f.font = .systemFont(ofSize: 20, weight: NSFont.Weight.medium)
+        f.font = .systemFont(ofSize: 20, weight: .medium)
         f.textColor = .externalPlaybackText
         f.alignment = .center
 

--- a/PlayerUI/Views/PUIButton.swift
+++ b/PlayerUI/Views/PUIButton.swift
@@ -148,7 +148,7 @@ public final class PUIButton: NSControl {
         shouldDrawHighlighted = true
 
         if !sendsActionOnMouseDown {
-            window?.trackEvents(matching: [NSEvent.EventTypeMask.leftMouseUp, NSEvent.EventTypeMask.leftMouseDragged], timeout: NSEvent.foreverDuration, mode: .eventTrackingRunLoopMode) { e, stop in
+            window?.trackEvents(matching: [.leftMouseUp, .leftMouseDragged], timeout: NSEvent.foreverDuration, mode: .eventTrackingRunLoopMode) { e, stop in
                 if e?.type == .leftMouseUp {
                     self.shouldDrawHighlighted = false
                     stop.pointee = true
@@ -178,7 +178,7 @@ public final class PUIButton: NSControl {
     }
 
     public override var effectiveAppearance: NSAppearance {
-        return NSAppearance(named: NSAppearance.Name.vibrantDark)!
+        return NSAppearance(named: .vibrantDark)!
     }
     
     public override var allowsVibrancy: Bool {

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -223,7 +223,7 @@ public final class PUIPlayerView: NSView {
             pictureContainer = PUIPictureContainerViewController(playerLayer: playerLayer)
             pictureContainer.delegate = self
             pictureContainer.view.frame = bounds
-            pictureContainer.view.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+            pictureContainer.view.autoresizingMask = [.width, .height]
 
             addSubview(pictureContainer.view)
         }
@@ -437,7 +437,7 @@ public final class PUIPlayerView: NSView {
         let l = NSTextField(labelWithString: "00:00:00")
 
         l.alignment = .left
-        l.font = .systemFont(ofSize: 14, weight: NSFont.Weight.medium)
+        l.font = .systemFont(ofSize: 14, weight: .medium)
         l.textColor = .timeLabel
 
         return l
@@ -447,7 +447,7 @@ public final class PUIPlayerView: NSView {
         let l = NSTextField(labelWithString: "-00:00:00")
 
         l.alignment = .right
-        l.font = .systemFont(ofSize: 14, weight: NSFont.Weight.medium)
+        l.font = .systemFont(ofSize: 14, weight: .medium)
         l.textColor = .timeLabel
 
         return l
@@ -636,9 +636,9 @@ public final class PUIPlayerView: NSView {
         centerButtonsContainerView = NSStackView(frame: bounds)
 
         // Leading controls (volume, subtitles)
-        centerButtonsContainerView.addView(volumeButton, in: NSStackView.Gravity.leading)
-        centerButtonsContainerView.addView(volumeSlider, in: NSStackView.Gravity.leading)
-        centerButtonsContainerView.addView(subtitlesButton, in: NSStackView.Gravity.leading)
+        centerButtonsContainerView.addView(volumeButton, in: .leading)
+        centerButtonsContainerView.addView(volumeSlider, in: .leading)
+        centerButtonsContainerView.addView(subtitlesButton, in: .leading)
 
         centerButtonsContainerView.setCustomSpacing(6, after: volumeButton)
 
@@ -650,9 +650,9 @@ public final class PUIPlayerView: NSView {
         centerButtonsContainerView.addView(forwardButton, in: .center)
 
         // Trailing controls (speed, add annotation, pip)
-        centerButtonsContainerView.addView(speedButton, in: NSStackView.Gravity.trailing)
-        centerButtonsContainerView.addView(addAnnotationButton, in: NSStackView.Gravity.trailing)
-        centerButtonsContainerView.addView(pipButton, in: NSStackView.Gravity.trailing)
+        centerButtonsContainerView.addView(speedButton, in: .trailing)
+        centerButtonsContainerView.addView(addAnnotationButton, in: .trailing)
+        centerButtonsContainerView.addView(pipButton, in: .trailing)
 
         centerButtonsContainerView.orientation = .horizontal
         centerButtonsContainerView.spacing = 24
@@ -660,18 +660,18 @@ public final class PUIPlayerView: NSView {
         centerButtonsContainerView.alignment = .centerY
 
         // Visibility priorities
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: volumeButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: volumeSlider)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: subtitlesButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: backButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: previousAnnotationButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.mustHold, for: playButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: forwardButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: nextAnnotationButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: speedButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: addAnnotationButton)
-        centerButtonsContainerView.setVisibilityPriority(NSStackView.VisibilityPriority.detachOnlyIfNecessary, for: pipButton)
-        centerButtonsContainerView.setContentCompressionResistancePriority(NSLayoutConstraint.Priority.defaultLow, for: .horizontal)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: volumeButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: volumeSlider)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: subtitlesButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: backButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: previousAnnotationButton)
+        centerButtonsContainerView.setVisibilityPriority(.mustHold, for: playButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: forwardButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: nextAnnotationButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: speedButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: addAnnotationButton)
+        centerButtonsContainerView.setVisibilityPriority(.detachOnlyIfNecessary, for: pipButton)
+        centerButtonsContainerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         // Main stack view
         controlsContainerView = NSStackView(views: [
@@ -929,7 +929,7 @@ public final class PUIPlayerView: NSView {
     private func updateMediaSelection() {
         guard let playerItem = player?.currentItem else { return }
 
-        guard let subtitlesGroup = playerItem.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristic.legible) else {
+        guard let subtitlesGroup = playerItem.asset.mediaSelectionGroup(forMediaCharacteristic: .legible) else {
             subtitlesButton.isHidden = true
             return
         }
@@ -1013,7 +1013,7 @@ public final class PUIPlayerView: NSView {
             stopMonitoringKeyEvents()
         }
 
-        keyDownEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [NSEvent.EventTypeMask.keyDown]) { [unowned self] event in
+        keyDownEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [unowned self] event in
             guard let command = KeyCommands(rawValue: event.keyCode) else {
                 return event
             }
@@ -1178,7 +1178,7 @@ public final class PUIPlayerView: NSView {
     private var windowIsInFullScreen: Bool {
         guard let window = window else { return false }
 
-        return window.styleMask.contains(NSWindow.StyleMask.fullScreen)
+        return window.styleMask.contains(.fullScreen)
     }
 
     @objc private func windowWillEnterFullScreen() {
@@ -1202,7 +1202,7 @@ public final class PUIPlayerView: NSView {
             removeTrackingArea(mouseTrackingArea)
         }
 
-        let options: NSTrackingArea.Options = [NSTrackingArea.Options.mouseEnteredAndExited, NSTrackingArea.Options.mouseMoved, NSTrackingArea.Options.activeAlways, NSTrackingArea.Options.inVisibleRect]
+        let options: NSTrackingArea.Options = [.mouseEnteredAndExited, .mouseMoved, .activeAlways, .inVisibleRect]
         mouseTrackingArea = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
 
         addTrackingArea(mouseTrackingArea)

--- a/PlayerUI/Views/PUIPlayerWindow.swift
+++ b/PlayerUI/Views/PUIPlayerWindow.swift
@@ -17,7 +17,7 @@ open class PUIPlayerWindow: NSWindow {
 
     public override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask, backing bufferingType: NSWindow.BackingStoreType, defer flag: Bool) {
         var effectiveStyle = style
-        effectiveStyle.insert(NSWindow.StyleMask.fullSizeContentView)
+        effectiveStyle.insert(.fullSizeContentView)
 
         super.init(contentRect: contentRect, styleMask: effectiveStyle, backing: bufferingType, defer: flag)
 
@@ -33,13 +33,13 @@ open class PUIPlayerWindow: NSWindow {
     // MARK: - Custom appearance
 
     open override var effectiveAppearance: NSAppearance {
-        return NSAppearance(named: NSAppearance.Name.vibrantDark)!
+        return NSAppearance(named: .vibrantDark)!
     }
 
     fileprivate var titlebarWidgets = Set<NSButton>()
 
     fileprivate func appearanceForWidgets() -> NSAppearance? {
-        return NSAppearance(named: NSAppearance.Name.aqua)
+        return NSAppearance(named: .aqua)
     }
 
     fileprivate func applyAppearanceToWidgets() {
@@ -203,7 +203,7 @@ open class PUIPlayerWindow: NSWindow {
         set {
             let darkContentView = PUIPlayerWindowContentView(frame: newValue?.frame ?? NSZeroRect)
             if let newContentView = newValue {
-                newContentView.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+                newContentView.autoresizingMask = [.width, .height]
                 darkContentView.addSubview(newContentView)
             }
             super.contentView = darkContentView
@@ -221,7 +221,7 @@ private class PUIPlayerWindowContentView: NSView {
 
     fileprivate func installOverlayView() {
         overlayView = PUIPlayerWindowOverlayView(frame: bounds)
-        overlayView!.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+        overlayView!.autoresizingMask = [.width, .height]
         addSubview(overlayView!, positioned: .above, relativeTo: subviews.last)
     }
 
@@ -264,7 +264,7 @@ private class PUIPlayerWindowOverlayView: NSView {
             removeTrackingArea(mouseTrackingArea)
         }
 
-        mouseTrackingArea = NSTrackingArea(rect: bounds, options: [NSTrackingArea.Options.inVisibleRect, NSTrackingArea.Options.mouseEnteredAndExited, NSTrackingArea.Options.mouseMoved, NSTrackingArea.Options.activeAlways], owner: self, userInfo: nil)
+        mouseTrackingArea = NSTrackingArea(rect: bounds, options: [.inVisibleRect, .mouseEnteredAndExited, .mouseMoved, .activeAlways], owner: self, userInfo: nil)
         addTrackingArea(mouseTrackingArea)
     }
 

--- a/PlayerUI/Views/PUITimelineView.swift
+++ b/PlayerUI/Views/PUITimelineView.swift
@@ -176,7 +176,7 @@ public final class PUITimelineView: NSView {
             removeTrackingArea(mouseTrackingArea)
         }
 
-        let options: NSTrackingArea.Options = [NSTrackingArea.Options.mouseEnteredAndExited, NSTrackingArea.Options.mouseMoved, NSTrackingArea.Options.activeInActiveApp]
+        let options: NSTrackingArea.Options = [.mouseEnteredAndExited, .mouseMoved, .activeInActiveApp]
         let trackingBounds = bounds.insetBy(dx: -2.5, dy: -7)
         mouseTrackingArea = NSTrackingArea(rect: trackingBounds, options: options, owner: self, userInfo: nil)
 
@@ -236,7 +236,7 @@ public final class PUITimelineView: NSView {
 
         var startedInteractiveSeek = false
 
-        window?.trackEvents(matching: [NSEvent.EventTypeMask.pressure, NSEvent.EventTypeMask.leftMouseUp, NSEvent.EventTypeMask.leftMouseDragged, NSEvent.EventTypeMask.tabletPoint], timeout: NSEvent.foreverDuration, mode: .eventTrackingRunLoopMode) { e, stop in
+        window?.trackEvents(matching: [.pressure, .leftMouseUp, .leftMouseDragged, .tabletPoint], timeout: NSEvent.foreverDuration, mode: .eventTrackingRunLoopMode) { e, stop in
             let point = self.convert((e?.locationInWindow)!, from: nil)
             let progress = Double(point.x / self.bounds.width)
 
@@ -280,7 +280,7 @@ public final class PUITimelineView: NSView {
             }
         }
 
-        NSApp.discardEvents(matching: NSEvent.EventTypeMask.leftMouseDown, before: nil)
+        NSApp.discardEvents(matching: .leftMouseDown, before: nil)
     }
 
     private func reactToMouse() {
@@ -358,7 +358,7 @@ public final class PUITimelineView: NSView {
         pStyle.alignment = .center
 
         let timeTextAttributes: [NSAttributedStringKey: Any] = [
-            .font: NSFont.systemFont(ofSize: 14, weight: NSFont.Weight.medium),
+            .font: NSFont.systemFont(ofSize: 14, weight: .medium),
             .foregroundColor: NSColor.playerHighlight,
             .paragraphStyle: pStyle
         ]
@@ -552,7 +552,7 @@ public final class PUITimelineView: NSView {
             layer.attachedLayer.string = str
         }
 
-        window?.trackEvents(matching: [NSEvent.EventTypeMask.leftMouseUp, NSEvent.EventTypeMask.leftMouseDragged, NSEvent.EventTypeMask.keyUp], timeout: NSEvent.foreverDuration, mode: .eventTrackingRunLoopMode) { event, stop in
+        window?.trackEvents(matching: [.leftMouseUp, .leftMouseDragged, .keyUp], timeout: NSEvent.foreverDuration, mode: .eventTrackingRunLoopMode) { event, stop in
             let point = self.convert((event?.locationInWindow)!, from: nil)
 
             switch event?.type {
@@ -661,7 +661,7 @@ public final class PUITimelineView: NSView {
         guard let contentView = annotationWindowController?.window?.contentView else { return }
 
         controller.view.frame = contentView.bounds
-        controller.view.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+        controller.view.autoresizingMask = [.width, .height]
         contentView.addSubview(controller.view)
 
         let layerRect = convertFromLayer(annotationLayer.frame)
@@ -689,12 +689,12 @@ public final class PUITimelineView: NSView {
             case enter = 36
         }
 
-        annotationCommandsMonitor = NSEvent.addLocalMonitorForEvents(matching: [NSEvent.EventTypeMask.keyUp]) { event in
+        annotationCommandsMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyUp) { event in
             guard let command = AnnotationKeyCommand(rawValue: event.keyCode) else { return event }
 
             switch command {
             case .enter:
-                if event.modifierFlags.contains(NSEvent.ModifierFlags.command) {
+                if event.modifierFlags.contains(.command) {
                     fallthrough
                 }
             case .escape:

--- a/WWDC/AboutWindowController.swift
+++ b/WWDC/AboutWindowController.swift
@@ -37,15 +37,15 @@ final class AboutWindowController: NSWindowController {
         super.windowDidLoad()
         
         // close the window when the escape key is pressed
-        NSEvent.addLocalMonitorForEvents(matching: NSEvent.EventTypeMask.keyDown) { event in
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.keyCode == 53 else { return event }
             
             self.closeAnimated()
             
             return nil
         }
-        
-        window?.collectionBehavior = [NSWindow.CollectionBehavior.transient, NSWindow.CollectionBehavior.ignoresCycle]
+
+        window?.collectionBehavior = [.transient, .ignoresCycle]
         window?.isMovableByWindowBackground = true
         window?.titlebarAppearsTransparent = true
         window?.titleVisibility = .hidden

--- a/WWDC/AccountPreferencesViewController.swift
+++ b/WWDC/AccountPreferencesViewController.swift
@@ -61,7 +61,7 @@ class AccountPreferencesViewController: NSViewController, WWDCImageViewDelegate 
     private lazy var nameLabel: NSTextField = {
         let f = NSTextField(labelWithString: "")
 
-        f.font = .systemFont(ofSize: 18, weight: NSFont.Weight.medium)
+        f.font = .systemFont(ofSize: 18, weight: .medium)
         f.textColor = .prefsPrimaryText
         f.translatesAutoresizingMaskIntoConstraints = false
         f.alignment = .center
@@ -74,7 +74,7 @@ class AccountPreferencesViewController: NSViewController, WWDCImageViewDelegate 
 
         let f = WWDCTextField(wrappingLabelWithString: help)
 
-        f.font = .systemFont(ofSize: 14, weight: NSFont.Weight.regular)
+        f.font = .systemFont(ofSize: 14, weight: .regular)
         f.textColor = .prefsSecondaryText
         f.cell?.backgroundStyle = .dark
         f.maximumNumberOfLines = 5
@@ -91,7 +91,7 @@ class AccountPreferencesViewController: NSViewController, WWDCImageViewDelegate 
         let f = WWDCTextField(wrappingLabelWithString: help)
 
         f.isSelectable = false
-        f.font = .systemFont(ofSize: 14, weight: NSFont.Weight.medium)
+        f.font = .systemFont(ofSize: 14, weight: .medium)
         f.textColor = .prefsPrimaryText
         f.cell?.backgroundStyle = .dark
         f.maximumNumberOfLines = 5
@@ -106,7 +106,7 @@ class AccountPreferencesViewController: NSViewController, WWDCImageViewDelegate 
 
         let f = NSTextField(wrappingLabelWithString: help)
 
-        f.font = .systemFont(ofSize: 14, weight: NSFont.Weight.regular)
+        f.font = .systemFont(ofSize: 14, weight: .regular)
         f.textColor = .errorText
         f.cell?.backgroundStyle = .dark
         f.maximumNumberOfLines = 5

--- a/WWDC/ActionLabel.swift
+++ b/WWDC/ActionLabel.swift
@@ -20,7 +20,7 @@ final class ActionLabel: NSTextField {
         }
 
         cursorTrackingArea = NSTrackingArea(rect: bounds,
-                                            options: [NSTrackingArea.Options.cursorUpdate, NSTrackingArea.Options.inVisibleRect, NSTrackingArea.Options.activeInActiveApp],
+                                            options: [.cursorUpdate, .inVisibleRect, .activeInActiveApp],
                                             owner: self,
                                             userInfo: nil)
         addTrackingArea(cursorTrackingArea)

--- a/WWDC/BookmarkViewController.swift
+++ b/WWDC/BookmarkViewController.swift
@@ -70,7 +70,7 @@ final class BookmarkViewController: NSViewController {
         v.backgroundColor = .clear
         v.font = .systemFont(ofSize: 12)
         v.textColor = .secondaryText
-        v.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+        v.autoresizingMask = [.width, .height]
 
         return v
     }()

--- a/WWDC/MainWindowController.swift
+++ b/WWDC/MainWindowController.swift
@@ -34,7 +34,7 @@ final class MainWindowController: NSWindowController {
     public var sidebarInitWidth: CGFloat?
 
     init() {
-        let mask: NSWindow.StyleMask = [NSWindow.StyleMask.titled, NSWindow.StyleMask.resizable, NSWindow.StyleMask.miniaturizable, NSWindow.StyleMask.closable]
+        let mask: NSWindow.StyleMask = [.titled, .resizable, .miniaturizable, .closable]
         let window = WWDCWindow(contentRect: MainWindowController.defaultRect, styleMask: mask, backing: .buffered, defer: false)
 
         super.init(window: window)

--- a/WWDC/ModalLoadingView.swift
+++ b/WWDC/ModalLoadingView.swift
@@ -63,7 +63,7 @@ class ModalLoadingView: NSView {
 
     func show(in view: NSView) {
         alphaValue = 0
-        autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+        autoresizingMask = [.width, .height]
         spinner.startAnimation(nil)
 
         view.addSubview(self)

--- a/WWDC/NSTableView+IGListKit.swift
+++ b/WWDC/NSTableView+IGListKit.swift
@@ -20,8 +20,8 @@ extension NSTableView {
         let diff = IGListDiff(oldValue, newValue, .equality)
 
         beginUpdates()
-        insertRows(at: diff.inserts, withAnimation: NSTableView.AnimationOptions.effectGap)
-        removeRows(at: diff.deletes, withAnimation: NSTableView.AnimationOptions.effectGap)
+        insertRows(at: diff.inserts, withAnimation: .effectGap)
+        removeRows(at: diff.deletes, withAnimation: .effectGap)
         reloadData(forRowIndexes: diff.updates, columnIndexes: IndexSet([0]))
         endUpdates()
     }

--- a/WWDC/PreferencesWindowController.swift
+++ b/WWDC/PreferencesWindowController.swift
@@ -15,7 +15,7 @@ class PreferencesWindowController: NSWindowController {
     }
 
     init() {
-        let mask: NSWindow.StyleMask = [NSWindow.StyleMask.titled, NSWindow.StyleMask.closable]
+        let mask: NSWindow.StyleMask = [.titled, .closable]
         let window = WWDCWindow(contentRect: PreferencesWindowController.defaultRect, styleMask: mask, backing: .buffered, defer: false)
 
         super.init(window: window)

--- a/WWDC/SessionActionsViewController.swift
+++ b/WWDC/SessionActionsViewController.swift
@@ -146,7 +146,7 @@ class SessionActionsViewController: NSViewController {
         view.wantsLayer = true
         view.translatesAutoresizingMaskIntoConstraints = false
 
-        view.setContentHuggingPriority(NSLayoutConstraint.Priority.defaultHigh, for: .horizontal)
+        view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 
     override func viewDidLoad() {

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -129,8 +129,8 @@ class SessionDetailsViewController: NSViewController {
         let v = SessionDetailsTabContainer()
 
         v.wantsLayer = true
-        v.setContentHuggingPriority(NSLayoutConstraint.Priority.defaultLow, for: .horizontal)
-        v.setContentHuggingPriority(NSLayoutConstraint.Priority.defaultLow, for: .vertical)
+        v.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        v.setContentHuggingPriority(.defaultLow, for: .vertical)
 
         return v
     }()
@@ -191,7 +191,7 @@ class SessionDetailsViewController: NSViewController {
         constraint.priority = NSLayoutConstraint.Priority(rawValue: 999)
         constraint.isActive = true
 
-        shelfController.view.setContentCompressionResistancePriority(NSLayoutConstraint.Priority.defaultHigh, for: .vertical)
+        shelfController.view.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
         view.addSubview(shelfController.view)
         view.addSubview(informationStackView)
@@ -254,7 +254,7 @@ fileprivate class SessionDetailsTabContainer: NSView {
             oldValue?.removeFromSuperview()
 
             if let newView = currentView {
-                newView.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+                newView.autoresizingMask = [.width, .height]
                 newView.frame = frame
 
                 addSubview(newView)

--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -32,7 +32,7 @@ class SessionSummaryViewController: NSViewController {
         let l = WWDCTextField(labelWithString: "")
         l.cell?.backgroundStyle = .dark
         l.lineBreakMode = .byWordWrapping
-        l.setContentCompressionResistancePriority(NSLayoutConstraint.Priority.defaultLow, for: .horizontal)
+        l.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         l.allowsDefaultTighteningForTruncation = true
         l.maximumNumberOfLines = 2
         l.translatesAutoresizingMaskIntoConstraints = false
@@ -56,7 +56,7 @@ class SessionSummaryViewController: NSViewController {
         l.cell?.backgroundStyle = .dark
         l.isSelectable = true
         l.lineBreakMode = .byWordWrapping
-        l.setContentCompressionResistancePriority(NSLayoutConstraint.Priority.defaultLow, for: .horizontal)
+        l.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         l.allowsDefaultTighteningForTruncation = true
         l.maximumNumberOfLines = 5
 
@@ -94,7 +94,7 @@ class SessionSummaryViewController: NSViewController {
         view.addSubview(actionsViewController.view)
         view.addSubview(stackView)
 
-        titleLabel.setContentHuggingPriority(NSLayoutConstraint.Priority.defaultLow, for: .horizontal)
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         actionsViewController.view.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor).isActive = true
         actionsViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true

--- a/WWDC/SessionTableCellView.swift
+++ b/WWDC/SessionTableCellView.swift
@@ -116,7 +116,7 @@ final class SessionTableCellView: NSTableCellView {
 
     private lazy var titleLabel: NSTextField = {
         let l = NSTextField(labelWithString: "")
-        l.font = .systemFont(ofSize: 14, weight: NSFont.Weight.medium)
+        l.font = .systemFont(ofSize: 14, weight: .medium)
         l.textColor = .primaryText
         l.cell?.backgroundStyle = .dark
         l.lineBreakMode = .byTruncatingTail

--- a/WWDC/SessionsSplitViewController.swift
+++ b/WWDC/SessionsSplitViewController.swift
@@ -46,9 +46,9 @@ final class SessionsSplitViewController: NSSplitViewController {
         addSplitViewItem(listItem)
         addSplitViewItem(detailItem)
 
-        listViewController.view.setContentHuggingPriority(NSLayoutConstraint.Priority.defaultHigh, for: .horizontal)
-        detailViewController.view.setContentHuggingPriority(NSLayoutConstraint.Priority.defaultLow, for: .horizontal)
-        detailViewController.view.setContentCompressionResistancePriority(NSLayoutConstraint.Priority.defaultHigh, for: .horizontal)
+        listViewController.view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        detailViewController.view.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        detailViewController.view.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
     }
 
     override func viewDidAppear() {

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -348,9 +348,9 @@ class SessionsTableViewController: NSViewController {
         v.backgroundColor = .listBackground
         v.headerView = nil
         v.rowHeight = Metrics.sessionRowHeight
-        v.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+        v.autoresizingMask = [.width, .height]
         v.floatsGroupRows = true
-        v.gridStyleMask = NSTableView.GridLineStyle.solidHorizontalGridLineMask
+        v.gridStyleMask = .solidHorizontalGridLineMask
         v.gridColor = .darkGridColor
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "session"))

--- a/WWDC/TabItemView.swift
+++ b/WWDC/TabItemView.swift
@@ -66,7 +66,7 @@ final class TabItemView: NSView {
                 imageView.tintColor = .toolbarTintActive
                 imageView.image = alternateImage ?? image
                 titleLabel.textColor = .toolbarTintActive
-                titleLabel.font = .systemFont(ofSize: 14, weight: NSFont.Weight.medium)
+                titleLabel.font = .systemFont(ofSize: 14, weight: .medium)
             } else {
                 imageView.tintColor = .toolbarTint
                 imageView.image = image

--- a/WWDC/TitleTableCellView.swift
+++ b/WWDC/TitleTableCellView.swift
@@ -28,7 +28,7 @@ class TitleTableCellView: NSTableCellView {
 
     private lazy var titleLabel: NSTextField = {
         let l = NSTextField(labelWithString: "")
-        l.font = .systemFont(ofSize: 12, weight: NSFont.Weight.medium)
+        l.font = .systemFont(ofSize: 12, weight: .medium)
         l.textColor = .darkText
         // l.cell?.backgroundStyle = .dark
         l.lineBreakMode = .byTruncatingTail

--- a/WWDC/TranscriptTableCellView.swift
+++ b/WWDC/TranscriptTableCellView.swift
@@ -32,7 +32,7 @@ class TranscriptTableCellView: NSTableCellView {
         let l = NSTextField(labelWithString: "")
 
         l.translatesAutoresizingMaskIntoConstraints = false
-        l.font = .systemFont(ofSize: 14, weight: NSFont.Weight.medium)
+        l.font = .systemFont(ofSize: 14, weight: .medium)
         l.textColor = .primaryText
         l.cell?.backgroundStyle = .dark
         l.lineBreakMode = .byTruncatingTail

--- a/WWDC/TranscriptTableViewController.swift
+++ b/WWDC/TranscriptTableViewController.swift
@@ -43,7 +43,7 @@ class TranscriptTableViewController: NSViewController {
         v.backgroundColor = .clear
         v.headerView = nil
         v.rowHeight = 36
-        v.autoresizingMask = [NSView.AutoresizingMask.width, NSView.AutoresizingMask.height]
+        v.autoresizingMask = [.width, .height]
         v.floatsGroupRows = true
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "transcript"))
@@ -76,7 +76,7 @@ class TranscriptTableViewController: NSViewController {
         tableView.frame = view.bounds
 
         view.heightAnchor.constraint(equalToConstant: 180).isActive = true
-        view.setContentCompressionResistancePriority(NSLayoutConstraint.Priority.defaultLow, for: .vertical)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
 
         view.addSubview(scrollView)
 

--- a/WWDC/VibrantButton.swift
+++ b/WWDC/VibrantButton.swift
@@ -61,7 +61,7 @@ class VibrantButton: NSView {
         v.translatesAutoresizingMaskIntoConstraints = false
         v.blendingMode = .withinWindow
         v.material = .ultraDark
-        v.appearance = NSAppearance(named: NSAppearance.Name.vibrantDark)
+        v.appearance = NSAppearance(named: .vibrantDark)
         v.state = .active
 
         return v

--- a/WWDC/VideoPlayerWindowController.swift
+++ b/WWDC/VideoPlayerWindowController.swift
@@ -28,7 +28,7 @@ final class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
         self.fullscreenOnly = fullscreenOnly
         self.originalContainer = originalContainer
 
-        let styleMask: NSWindow.StyleMask = [NSWindow.StyleMask.titled, NSWindow.StyleMask.closable, NSWindow.StyleMask.miniaturizable, NSWindow.StyleMask.resizable, NSWindow.StyleMask.fullSizeContentView]
+        let styleMask: NSWindow.StyleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
 
         var rect = PUIPlayerWindow.bestScreenRectFromDetachingContainer(playerViewController.view.superview)
         if rect == NSZeroRect { rect = PUIPlayerWindow.centerRectForProposedContentRect(playerViewController.view.bounds) }
@@ -39,7 +39,7 @@ final class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
         if #available(OSX 10.11, *) {
             // ¯\_(ツ)_/¯
         } else {
-            window.collectionBehavior = NSWindow.CollectionBehavior.fullScreenPrimary
+            window.collectionBehavior = .fullScreenPrimary
         }
 
         super.init(window: window)

--- a/WWDC/WWDCTabViewController.swift
+++ b/WWDC/WWDCTabViewController.swift
@@ -50,7 +50,7 @@ class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Ta
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        transitionOptions = [NSViewController.TransitionOptions.allowUserInteraction]
+        transitionOptions = .allowUserInteraction
 
         tabStyle = .toolbar
         view.wantsLayer = true
@@ -73,8 +73,8 @@ class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Ta
 
         isConfigured = true
 
-        toolbar.insertItem(withItemIdentifier: NSToolbarItem.Identifier.flexibleSpace, at: 0)
-        toolbar.insertItem(withItemIdentifier: NSToolbarItem.Identifier.flexibleSpace, at: toolbar.items.count)
+        toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: 0)
+        toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: toolbar.items.count)
 
         addObserver(self, forKeyPath: #keyPath(selectedTabViewItemIndex), options: [.initial, .new], context: nil)
 

--- a/WWDC/WWDCTableView.swift
+++ b/WWDC/WWDCTableView.swift
@@ -19,6 +19,6 @@ class WWDCTableView: NSTableView {
     }
     
     override var effectiveAppearance: NSAppearance {
-        return NSAppearance(named: NSAppearance.Name.vibrantDark)!
+        return NSAppearance(named: .vibrantDark)!
     }
 }

--- a/WWDC/WWDCTextButton.swift
+++ b/WWDC/WWDCTextButton.swift
@@ -31,7 +31,7 @@ class WWDCTextButton: NSButton {
         
         if state == .on {
             let attrs: [NSAttributedStringKey: Any] = [
-                .font: NSFont.systemFont(ofSize: 16, weight: NSFont.Weight.medium),
+                .font: NSFont.systemFont(ofSize: 16, weight: .medium),
                 .foregroundColor: NSColor.primary
             ]
             

--- a/WWDC/WWDCWindow.swift
+++ b/WWDC/WWDCWindow.swift
@@ -45,7 +45,7 @@ class WWDCWindow: NSWindow {
 
         titleVisibility = .hidden
         isMovableByWindowBackground = true
-        tabbingMode = NSWindow.TabbingMode.disallowed
+        tabbingMode = .disallowed
 
         titlebarView?.material = .ultraDark
         titlebarView?.state = .inactive


### PR DESCRIPTION
Swift 4 opened a lot of possibilities for less verbosity, unfortunately the migration tool did not make full use of it.