### PR TITLE
Temp fix: Allows Schedule view to parse data from previous year

### DIFF
--- a/ConfCore/SessionInstancesJSONAdapter.swift
+++ b/ConfCore/SessionInstancesJSONAdapter.swift
@@ -30,8 +30,11 @@ final class SessionInstancesJSONAdapter: Adapter {
             return .error(.invalidData)
         }
 
-        // not an instance
-        guard session.year == Calendar.current.component(.year, from: Date()) else {
+        var year = Calendar.current.component(.year, from: Date())
+        if Calendar.current.component(.month, from: Date()) < 6 {
+            year -= 1
+        }
+        guard session.year == year else {
             return .error(.invalidData)
         }
 


### PR DESCRIPTION
Temporary fix for #340. This still makes assumptions about the WWDC month, however, & probably will cause problems as soon as a new schedule is released.

Matters are complicated further by the fall-2017 "event". If this is representative of something longer term, we should probably attempt to move away from relying on year too heavily.