### PR TITLE
Address all warnings except cyclomatic complexity

### DIFF
--- a/ConfCore/AppleAPIClient.swift
+++ b/ConfCore/AppleAPIClient.swift
@@ -17,14 +17,22 @@ public final class AppleAPIClient {
     fileprivate var environment: Environment
     fileprivate var service: Service
 
+    private var environmentChangeToken: NSObjectProtocol?
+
     public init(environment: Environment) {
         self.environment = environment
         service = Service(baseURL: environment.baseURL)
 
         configureService()
 
-        NotificationCenter.default.addObserver(forName: .WWDCEnvironmentDidChange, object: nil, queue: OperationQueue.main) { _ in
-            self.updateEnvironment()
+        environmentChangeToken = NotificationCenter.default.addObserver(forName: .WWDCEnvironmentDidChange, object: nil, queue: .main) { [weak self] _ in
+            self?.updateEnvironment()
+        }
+    }
+
+    deinit {
+        if let token = environmentChangeToken {
+            NotificationCenter.default.removeObserver(token)
         }
     }
 

--- a/ConfCore/ContributorsFetcher.swift
+++ b/ConfCore/ContributorsFetcher.swift
@@ -102,8 +102,11 @@ private struct GitHubPagination {
     var previous: URL?
     var last: URL?
 
+    // swiftlint:disable force_try
+    // As these regex's are constants, we don't need to worry about the failures
     private static let urlRegex = try! NSRegularExpression(pattern: "<(.*)>", options: [])
     private static let typeRegex = try! NSRegularExpression(pattern: "rel=\"(.*)\"", options: [])
+    // swiftlint:enable force_try
 
     init?(linkHeader: String) {
         let links: [(URL, String)] = linkHeader.components(separatedBy: ",").flatMap { link in

--- a/ConfCore/SyncEngine.swift
+++ b/ConfCore/SyncEngine.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import RxCocoa
 import RxSwift
 
 extension Notification.Name {
@@ -32,13 +33,15 @@ public final class SyncEngine {
         return transcriptIndexingConnection.remoteObjectProxy as? TranscriptIndexingServiceProtocol
     }
 
+    private let disposeBag = DisposeBag()
+
     public init(storage: Storage, client: AppleAPIClient) {
         self.storage = storage
         self.client = client
 
-        NotificationCenter.default.addObserver(forName: .SyncEngineDidSyncSessionsAndSchedule, object: nil, queue: OperationQueue.main) { [unowned self] _ in
+        NotificationCenter.default.rx.notification(.SyncEngineDidSyncSessionsAndSchedule).observeOn(MainScheduler.instance).subscribe(onNext: { [unowned self] _ in
             self.startTranscriptIndexingIfNeeded()
-        }
+        }).disposed(by: disposeBag)
     }
 
     public func syncContent() {

--- a/ConfCoreTests/StorageTests.swift
+++ b/ConfCoreTests/StorageTests.swift
@@ -14,17 +14,16 @@ class StorageTests: XCTestCase {
 
     private var realmConfig: Realm.Configuration!
     private var realm: Realm!
+    private var storage: Storage!
 
     override func setUp() {
         super.setUp()
 
-        realmConfig = Realm.makeInMemoryConfiguration()
-        realm = try! Realm(configuration: realmConfig)
+        storage = tryOrXCTFail(try Storage(Realm.makeInMemoryConfiguration()))
+        realm = storage.realm
     }
 
     func test() {
-        let storage = try! Storage(realmConfig)
-
         let contentsResponse = makeContentsResponse()
 
         let storeExpectation = expectation(description: "Store completion")

--- a/ConfCoreTests/Util/Realm+InMemory.swift
+++ b/ConfCoreTests/Util/Realm+InMemory.swift
@@ -15,6 +15,6 @@ extension Realm {
     }
 
     static func makeInMemory() -> Realm {
-        return try! Realm(configuration: makeInMemoryConfiguration())
+        return tryOrXCTFail(try Realm(configuration: makeInMemoryConfiguration()))
     }
 }

--- a/ConfCoreTests/Util/TestUtilities.swift
+++ b/ConfCoreTests/Util/TestUtilities.swift
@@ -1,0 +1,18 @@
+//
+//  TestUtilities.swift
+//  ConfCoreTests
+//
+//  Created by Allen Humphreys on 3/8/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import XCTest
+
+func tryOrXCTFail<T>(_ thingToTry: @autoclosure () throws -> T, line: Int = #line) -> T {
+    do {
+        return try thingToTry()
+    } catch {
+        XCTFail("\(#function) called at line \(line) failed to produce type <\(T.self)> with error: \(error)")
+        fatalError()
+    }
+}

--- a/PlayerUI/.swiftlint.yml
+++ b/PlayerUI/.swiftlint.yml
@@ -1,0 +1,3 @@
+disabled_rules:
+  - cyclomatic_complexity
+  - block_based_kvo

--- a/PlayerUI/Views/PUIPlayerWindow.swift
+++ b/PlayerUI/Views/PUIPlayerWindow.swift
@@ -65,7 +65,8 @@ open class PUIPlayerWindow: NSWindow {
     fileprivate var titlebarSeparatorLayer: CALayer?
     fileprivate var titlebarGradientLayer: CAGradientLayer?
 
-    fileprivate var fullscreenObserver: NSObjectProtocol?
+    fileprivate var didEnterFullscreenObserver: NSObjectProtocol?
+    fileprivate var didExitFullscreenObserver: NSObjectProtocol?
 
     fileprivate func applyCustomizations(_ note: Notification? = nil) {
         titleVisibility = .hidden
@@ -131,13 +132,13 @@ open class PUIPlayerWindow: NSWindow {
     }
 
     fileprivate func installFullscreenObserverIfNeeded() {
-        guard fullscreenObserver == nil else { return }
+        guard didEnterFullscreenObserver == nil else { return }
 
         let nc = NotificationCenter.default
 
         // the customizations (especially the title text field ones) have to be reapplied when entering and exiting fullscreen
-        nc.addObserver(forName: NSWindow.didEnterFullScreenNotification, object: self, queue: nil, using: applyCustomizations)
-        nc.addObserver(forName: NSWindow.didExitFullScreenNotification, object: self, queue: nil, using: applyCustomizations)
+        didEnterFullscreenObserver = nc.addObserver(forName: NSWindow.didEnterFullScreenNotification, object: self, queue: nil, using: applyCustomizations)
+        didExitFullscreenObserver = nc.addObserver(forName: NSWindow.didExitFullScreenNotification, object: self, queue: nil, using: applyCustomizations)
     }
 
     open override func makeKeyAndOrderFront(_ sender: Any?) {

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		01B3EB4A1EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3EB491EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift */; };
 		3A0840B41F924665002BC828 /* Realm+InMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0840B31F924665002BC828 /* Realm+InMemory.swift */; };
 		3A6227031F9272A300D5F687 /* contents.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A6227021F9272A300D5F687 /* contents.json */; };
+		4DEEC3A32051C8D400376595 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEEC3A22051C8D400376595 /* TestUtilities.swift */; };
 		DD0159A71ECFE26200F980F1 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A61ECFE26200F980F1 /* DeepLink.swift */; };
 		DD0159A91ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */; };
 		DD0159CF1ED0CD3A00F980F1 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159CE1ED0CD3A00F980F1 /* PreferencesWindowController.swift */; };
@@ -358,6 +359,7 @@
 		01B3EB491EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+SessionTableViewContextMenuActions.swift"; sourceTree = "<group>"; };
 		3A0840B31F924665002BC828 /* Realm+InMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Realm+InMemory.swift"; sourceTree = "<group>"; };
 		3A6227021F9272A300D5F687 /* contents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = contents.json; sourceTree = "<group>"; };
+		4DEEC3A22051C8D400376595 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		DD0159A61ECFE26200F980F1 /* DeepLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+Bookmarks.swift"; sourceTree = "<group>"; };
 		DD0159CE1ED0CD3A00F980F1 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
@@ -682,6 +684,7 @@
 			isa = PBXGroup;
 			children = (
 				3A0840B31F924665002BC828 /* Realm+InMemory.swift */,
+				4DEEC3A22051C8D400376595 /* TestUtilities.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1971,6 +1974,7 @@
 			files = (
 				DD36A4D81E478D7E00B2EA88 /* StorageTests.swift in Sources */,
 				DD34DA071E4AB0E400F25C45 /* AdapterTests.swift in Sources */,
+				4DEEC3A32051C8D400376595 /* TestUtilities.swift in Sources */,
 				3A0840B41F924665002BC828 /* Realm+InMemory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -91,9 +91,9 @@ final class AppCoordinator {
         setupBindings()
         setupDelegation()
 
-        NotificationCenter.default.rx.notification(.WWDCTabViewControllerDidFinishLoading).subscribe(onNext: { [weak self] _ in self?.restoreApplicationState() }).disposed(by: disposeBag)
-        NotificationCenter.default.rx.notification(NSApplication.didFinishLaunchingNotification).subscribe(onNext: { [weak self] _ in self?.startup() }).disposed(by: disposeBag)
-        NotificationCenter.default.rx.notification(NSApplication.willTerminateNotification).subscribe(onNext: { [weak self] _ in self?.saveApplicationState() }).disposed(by: disposeBag)
+        _ = NotificationCenter.default.addObserver(forName: .WWDCTabViewControllerDidFinishLoading, object: nil, queue: nil) { _ in self.restoreApplicationState() }
+        _ = NotificationCenter.default.addObserver(forName: NSApplication.didFinishLaunchingNotification, object: nil, queue: nil) { _ in self.startup() }
+        _ = NotificationCenter.default.addObserver(forName: NSApplication.willTerminateNotification, object: nil, queue: nil) { _ in self.saveApplicationState() }
     }
 
     /// The list controller for the active tab
@@ -233,7 +233,7 @@ final class AppCoordinator {
         resetAutorefreshTimer()
     }
 
-    func startup() {
+    private func startup() {
         RemoteEnvironment.shared.start()
 
         ContributorsFetcher.shared.load()
@@ -245,17 +245,17 @@ final class AppCoordinator {
             tabController.showLoading()
         }
 
-        NotificationCenter.default.rx.notification(.SyncEngineDidSyncSessionsAndSchedule).observeOn(MainScheduler.instance).subscribe(onNext: { note in
+        _ = NotificationCenter.default.addObserver(forName: .SyncEngineDidSyncSessionsAndSchedule, object: nil, queue: .main) { note in
             if let error = note.object as? Error {
                 NSApp.presentError(error)
             } else {
                 self.updateListsAfterSync(migrate: true)
             }
-        }).disposed(by: disposeBag)
+        }
 
-        NotificationCenter.default.rx.notification(.WWDCEnvironmentDidChange).observeOn(MainScheduler.instance).subscribe(onNext: { _ in
+        _ = NotificationCenter.default.addObserver(forName: .WWDCEnvironmentDidChange, object: nil, queue: .main) { _ in
             self.refresh(nil)
-        }).disposed(by: disposeBag)
+        }
 
         refresh(nil)
         updateListsAfterSync()

--- a/WWDC/DownloadManager.swift
+++ b/WWDC/DownloadManager.swift
@@ -77,7 +77,7 @@ final class DownloadManager: NSObject {
             }
         }
 
-        NotificationCenter.default.addObserver(forName: .LocalVideoStoragePathPreferenceDidChange, object: nil, queue: nil) { _ in
+        _ = NotificationCenter.default.addObserver(forName: .LocalVideoStoragePathPreferenceDidChange, object: nil, queue: nil) { _ in
             self.monitorDownloadsFolder()
         }
 

--- a/WWDC/GeneralPreferencesViewController.swift
+++ b/WWDC/GeneralPreferencesViewController.swift
@@ -13,6 +13,7 @@ class GeneralPreferencesViewController: NSViewController {
     static func loadFromStoryboard() -> GeneralPreferencesViewController {
         let vc = NSStoryboard(name: NSStoryboard.Name(rawValue: "Preferences"), bundle: nil).instantiateController(withIdentifier: NSStoryboard.SceneIdentifier(rawValue: "GeneralPreferencesViewController"))
 
+        // swiftlint:disable:next force_cast
         return vc as! GeneralPreferencesViewController
     }
 

--- a/WWDC/LoggingHelper.swift
+++ b/WWDC/LoggingHelper.swift
@@ -42,7 +42,7 @@ final class LoggingHelper {
     }
 
     static func observeCommunityCenterNotifications() {
-        NotificationCenter.default.addObserver(forName: .CMSErrorOccurred, object: nil, queue: OperationQueue.main) { note in
+        _ = NotificationCenter.default.addObserver(forName: .CMSErrorOccurred, object: nil, queue: OperationQueue.main) { note in
             let error: Error
 
             if let noteError = note.object as? Error {
@@ -54,7 +54,7 @@ final class LoggingHelper {
             LoggingHelper.registerError(error, info: note.userInfo as? [String: Any])
         }
 
-        NotificationCenter.default.addObserver(forName: .CMSUserIdentifierDidBecomeAvailable, object: nil, queue: OperationQueue.main) { note in
+        _ = NotificationCenter.default.addObserver(forName: .CMSUserIdentifierDidBecomeAvailable, object: nil, queue: OperationQueue.main) { note in
             guard let identifier = note.object as? String else { return }
 
             LoggingHelper.registerCloudKitUserIdentifier(identifier)

--- a/WWDC/SearchFiltersViewController.swift
+++ b/WWDC/SearchFiltersViewController.swift
@@ -48,6 +48,7 @@ final class SearchFiltersViewController: NSViewController {
     static func loadFromStoryboard() -> SearchFiltersViewController {
         let storyboard = NSStoryboard(name: NSStoryboard.Name(rawValue: "Main"), bundle: nil)
 
+        // swiftlint:disable:next force_cast
         return storyboard.instantiateController(withIdentifier: NSStoryboard.SceneIdentifier(rawValue: "SearchFiltersViewController")) as! SearchFiltersViewController
     }
 

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -69,16 +69,10 @@ class SessionsTableViewController: NSViewController {
 
         displayedRowsLock.async {
 
-            let methodStart = Date()
-
             let oldValue = self.displayedRows
 
             // Same elements, same order: https://github.com/apple/swift/blob/master/stdlib/public/core/Arrays.swift.gyb#L2203
-            if oldValue == newValue {
-
-                print("Time to short circuit: \(Date().timeIntervalSince(methodStart))")
-                return
-            }
+            if oldValue == newValue { return }
 
             let oldRowsSet = Set(oldValue.enumerated().map { IndexedSessionRow(sessionRow: $1, index: $0) })
             let newRowsSet = Set(newValue.enumerated().map { IndexedSessionRow(sessionRow: $1, index: $0) })
@@ -88,8 +82,6 @@ class SessionsTableViewController: NSViewController {
 
             let removedIndexes = IndexSet(removed.map { $0.index })
             let addedIndexes = IndexSet(added.map { $0.index })
-
-            let complicatedOperationStart = Date()
 
             // Only reload rows if their relative positioning changes. This prevents
             // cell contents from flashing when cells are unnecessarily reloaded
@@ -103,22 +95,9 @@ class SessionsTableViewController: NSViewController {
                 return row1.index < row2.index
             })
 
-            #if DEBUG
-                print("Building the arrays took: \(Date().timeIntervalSince(complicatedOperationStart))")
-            #endif
-
-            let loopStart = Date()
             for (oldSessionRowIndex, newSessionRowIndex) in zip(sortedOldRows, sortedNewRows) where oldSessionRowIndex.sessionRow != newSessionRowIndex.sessionRow {
                 needReloadedIndexes.insert(newSessionRowIndex.index)
             }
-
-            #if DEBUG
-                print("The loop took: \(Date().timeIntervalSince(loopStart))")
-
-                print("The complicated calculation took: \(Date().timeIntervalSince(complicatedOperationStart))")
-            #endif
-
-            print("Set calculations took: \(Date().timeIntervalSince(methodStart))")
 
             DispatchQueue.main.sync {
 
@@ -169,10 +148,6 @@ class SessionsTableViewController: NSViewController {
 
                 self.tableView.endUpdates()
                 NSAnimationContext.endGrouping()
-
-                #if DEBUG
-                    print("Total time to table update took: \(Date().timeIntervalSince(methodStart))")
-                #endif
             }
         }
     }

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -179,15 +179,15 @@ final class VideoPlayerViewController: NSViewController {
 
     private func setupPlayerObservers() {
 
-        playerStatusObserver = player.observe(\AVPlayer.status, options: [.initial, .new], changeHandler: { [weak self] (player, change) in
-            guard let strongSelf = self else { return }
-            DispatchQueue.main.async(execute: strongSelf.playerItemPresentationSizeDidChange)
+        playerStatusObserver = player.observe(\.status, options: [.initial, .new], changeHandler: { [weak self] (player, change) in
+            guard let `self` = self else { return }
+            DispatchQueue.main.async(execute: self.playerStatusDidChange)
         })
 
-        currentItemObserver = player.observe(\AVPlayer.currentItem, options: [.initial, .new]) { [weak self] (player, change) in
+        currentItemObserver = player.observe(\.currentItem, options: [.initial, .new]) { [weak self] (player, change) in
             self?.presentationSizeObserver = player.currentItem?.observe(\.presentationSize, options: [.initial, .new]) { [weak self] (player, change) in
-                guard let strongSelf = self else { return }
-                DispatchQueue.main.async(execute: strongSelf.playerStatusDidChange)
+                guard let `self` = self else { return }
+                DispatchQueue.main.async(execute: self.playerItemPresentationSizeDidChange)
             }
         }
     }

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -116,10 +116,9 @@ final class VideoPlayerViewController: NSViewController {
 
         NotificationCenter.default.addObserver(self, selector: #selector(annotationSelected(notification:)), name: .TranscriptControllerDidSelectAnnotation, object: nil)
 
-        NotificationCenter.default.addObserver(forName: .SkipBackAndForwardBy30SecondsPreferenceDidChange, object: nil, queue: OperationQueue.main) { _ in
-            Swift.print("hello there!")
+        NotificationCenter.default.rx.notification(.SkipBackAndForwardBy30SecondsPreferenceDidChange).observeOn(MainScheduler.instance).subscribe { _ in
             self.playerView.invalidateAppearance()
-        }
+        }.disposed(by: disposeBag)
     }
 
     func resetAppearanceDelegate() {
@@ -137,12 +136,9 @@ final class VideoPlayerViewController: NSViewController {
 
             oldPlayer.pause()
             oldPlayer.cancelPendingPrerolls()
-            oldPlayer.removeObserver(self, forKeyPath: #keyPath(AVPlayer.status))
-            oldPlayer.removeObserver(self, forKeyPath: #keyPath(AVPlayer.currentItem.presentationSize))
         }
 
-        player.addObserver(self, forKeyPath: #keyPath(AVPlayer.status), options: [.initial, .new], context: nil)
-        player.addObserver(self, forKeyPath: #keyPath(AVPlayer.currentItem.presentationSize), options: [.initial, .new], context: nil)
+        setupPlayerObservers()
 
         player.play()
 
@@ -177,15 +173,22 @@ final class VideoPlayerViewController: NSViewController {
 
     // MARK: - Player Observation
 
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        guard let keyPath = keyPath else { return }
+    private var playerStatusObserver: NSKeyValueObservation?
+    private var presentationSizeObserver: NSKeyValueObservation?
+    private var currentItemObserver: NSKeyValueObservation?
 
-        if keyPath == #keyPath(AVPlayer.currentItem.presentationSize) {
-            DispatchQueue.main.async(execute: playerItemPresentationSizeDidChange)
-        } else if keyPath == #keyPath(AVPlayer.status) {
-            DispatchQueue.main.async(execute: playerStatusDidChange)
-        } else {
-            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+    private func setupPlayerObservers() {
+
+        playerStatusObserver = player.observe(\AVPlayer.status, options: [.initial, .new], changeHandler: { [weak self] (player, change) in
+            guard let strongSelf = self else { return }
+            DispatchQueue.main.async(execute: strongSelf.playerItemPresentationSizeDidChange)
+        })
+
+        currentItemObserver = player.observe(\AVPlayer.currentItem, options: [.initial, .new]) { [weak self] (player, change) in
+            self?.presentationSizeObserver = player.currentItem?.observe(\.presentationSize, options: [.initial, .new]) { [weak self] (player, change) in
+                guard let strongSelf = self else { return }
+                DispatchQueue.main.async(execute: strongSelf.playerStatusDidChange)
+            }
         }
     }
 

--- a/WWDC/VideoPlayerWindowController.swift
+++ b/WWDC/VideoPlayerWindowController.swift
@@ -24,6 +24,13 @@ final class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
 
     var actionOnWindowClosed = {}
 
+    var playerWindow: PUIPlayerWindow? {
+        let playerWindow = window as? PUIPlayerWindow
+        assert(playerWindow != nil, "Expected a valid window and found none")
+
+        return playerWindow
+    }
+
     init(playerViewController: VideoPlayerViewController, fullscreenOnly: Bool = false, originalContainer: NSView? = nil) {
         self.fullscreenOnly = fullscreenOnly
         self.originalContainer = originalContainer
@@ -62,7 +69,7 @@ final class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
         super.showWindow(sender)
 
         if !fullscreenOnly {
-            (window as! PUIPlayerWindow).applySizePreset(.half)
+            playerWindow?.applySizePreset(.half)
         } else {
             window?.toggleFullScreen(sender)
         }
@@ -119,15 +126,15 @@ final class VideoPlayerWindowController: NSWindowController, NSWindowDelegate {
     }
 
     @IBAction func sizeWindowToHalfSize(_ sender: AnyObject?) {
-        (window as! PUIPlayerWindow).applySizePreset(.half)
+        playerWindow?.applySizePreset(.half)
     }
 
     @IBAction func sizeWindowToQuarterSize(_ sender: AnyObject?) {
-        (window as! PUIPlayerWindow).applySizePreset(.quarter)
+        playerWindow?.applySizePreset(.quarter)
     }
 
     @IBAction func sizeWindowToFill(_ sender: AnyObject?) {
-        (window as! PUIPlayerWindow).applySizePreset(.max)
+        playerWindow?.applySizePreset(.max)
     }
 
     @IBAction func floatOnTop(_ sender: NSMenuItem) {


### PR DESCRIPTION
I added another `.swiftlint.yml` to the `PlayerUI` directory which disables 2 rules: cyclomatic_complexity, block_based_kvo. I did this because the player part of the app is quite complicated and it could take a considerable amount of time to safely refactor the affected parts.

I addressed the outstanding warnings for discarded Notification Center observers through a combination of explicitly ignoring the token in the case of singletons, using RxSwift to manage the lifetime, and using the object based tokens to manage the life time. I was unsure whether we wanted some classes to have a dependency on RxSwift just to manage notification lifetimes.

I address the KVO warnings, but I'm not sure I really like the result, thoughts?

I disabled the force_cast and force_try rules for certain issues. A different option would be to create a `castOrFatalError` helper function similar to the `tryOrXCTFail` function I created for silencing the warnings in the tests. 