### PR TITLE
Fix 2 contextual menu bugs in the sessions table

### DIFF
--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -67,6 +67,9 @@ class SessionsTableViewController: NSViewController {
 
     func setDisplayedRows(_ newValue: [SessionRow], animated: Bool) {
 
+        // Dismiss the menu when the displayed rows are about to change otherwise it will crash
+        tableView.menu?.cancelTrackingWithoutAnimation()
+
         displayedRowsLock.async {
 
             let methodStart = Date()

--- a/WWDC/WWDCTableView.swift
+++ b/WWDC/WWDCTableView.swift
@@ -21,4 +21,20 @@ class WWDCTableView: NSTableView {
     override var effectiveAppearance: NSAppearance {
         return NSAppearance(named: .vibrantDark)!
     }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+
+        let windowLocation = event.locationInWindow
+        let tableLocation = convert(windowLocation, from: nil)
+        let clickedRow = row(at: tableLocation)
+
+        if clickedRow >= 0,
+            let rowView = rowView(atRow: clickedRow, makeIfNecessary: false),
+            rowView.isGroupRowStyle {
+
+            return nil
+        }
+
+        return super.menu(for: event)
+    }
 }


### PR DESCRIPTION
 * Crash when the table updates asynchronously and a context menu is active
 * Context menu is allowed on group cells

To reproduce the crash, get the app so that the schedule tab is saved as the startup tab. Then launch the app and quickly right click on a session. I think there may be a big issue here as I'm not sure if this asynchronous update should be happening when it does... I will investigate further, but I wanted to at least get this fix in in case I don't get to the root of the problem.