### PR TITLE
Added flag to use separate storage in debug builds

### DIFF
--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
@@ -79,6 +79,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-WWDCUseDebugStorage YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--disable-transcripts"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC.xcscheme
@@ -73,6 +73,12 @@
             ReferencedContainer = "container:WWDC.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-WWDCUseDebugStorage YES"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT"

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -47,14 +47,16 @@ final class AppCoordinator {
     var isTransitioningPlayerContext = false
 
     init(windowController: MainWindowController) {
-        let filePath = PathUtil.appSupportPath + "/ConfCore.realm"
-
-        var realmConfig = Realm.Configuration(fileURL: URL(fileURLWithPath: filePath))
-        realmConfig.schemaVersion = Constants.coreSchemaVersion
-
-        let client = AppleAPIClient(environment: .current)
-
         do {
+            let supportPath = try PathUtil.appSupportPathCreatingIfNeeded()
+
+            let filePath = supportPath + "/ConfCore.realm"
+
+            var realmConfig = Realm.Configuration(fileURL: URL(fileURLWithPath: filePath))
+            realmConfig.schemaVersion = Constants.coreSchemaVersion
+
+            let client = AppleAPIClient(environment: .current)
+
             storage = try Storage(realmConfig)
 
             syncEngine = SyncEngine(storage: storage, client: client)
@@ -406,7 +408,7 @@ final class AppCoordinator {
 
         if migrator != nil { guard !migrator.isPerformingMigration else { return } }
 
-        let legacyURL = URL(fileURLWithPath: PathUtil.appSupportPath + "/default.realm")
+        let legacyURL = URL(fileURLWithPath: PathUtil.appSupportPathAssumingExisting + "/default.realm")
         migrator = TBUserDataMigrator(legacyDatabaseFileURL: legacyURL, newRealm: storage.realm)
 
         guard migrator.needsMigration && !TBUserDataMigrator.presentedMigrationPrompt else {

--- a/WWDC/ImageDownloadCenter.swift
+++ b/WWDC/ImageDownloadCenter.swift
@@ -77,7 +77,7 @@ private final class ImageCacheProvider {
     private let upperLimit = 16 * 1024 * 1024
 
     private func makeRealm() -> Realm? {
-        let filePath = PathUtil.appSupportPath + "/ImageCache.realm"
+        let filePath = PathUtil.appSupportPathAssumingExisting + "/ImageCache.realm"
 
         var realmConfig = Realm.Configuration(fileURL: URL(fileURLWithPath: filePath))
         realmConfig.objectTypes = [ImageCacheEntity.self]

--- a/WWDC/PathUtil.swift
+++ b/WWDC/PathUtil.swift
@@ -48,7 +48,7 @@ final class PathUtil {
         return path
     }
 
-    /// appSupportPathCreatingIfNeeded
+    /// Creates and returns the app support path
     ///
     /// - Returns: The path to the app support directory
     /// - Throws: If the directory doesn't exist and can't be created


### PR DESCRIPTION
This makes it so people who develop and also use the app don't mess up their production data during testing (@bcmn).

Just add `-WWDCUseDebugStorage YES` as an argument to the debug scheme. I have added it and left it enabled by default on both schemes since I believe this is something everybody will want to have enabled.

Future debugging improvements:
- Separate preferences
- Add menu to open database file in Realm Browser
- Add menu to copy production database to debug container