### PR TITLE
Fixes `viewDidAppear` not being called on SessionsTableViewController

### DIFF
--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -84,6 +84,8 @@ final class AppCoordinator {
         videosItem.label = "Videos"
         tabController.addTabViewItem(videosItem)
 
+        tabController.activeTab = Preferences.shared.activeTab
+
         self.windowController = windowController
 
         liveObserver = LiveObserver(dateProvider: today, storage: storage)
@@ -91,7 +93,6 @@ final class AppCoordinator {
         setupBindings()
         setupDelegation()
 
-        _ = NotificationCenter.default.addObserver(forName: .WWDCTabViewControllerDidFinishLoading, object: nil, queue: nil) { _ in self.restoreApplicationState() }
         _ = NotificationCenter.default.addObserver(forName: NSApplication.didFinishLaunchingNotification, object: nil, queue: nil) { _ in self.startup() }
         _ = NotificationCenter.default.addObserver(forName: NSApplication.willTerminateNotification, object: nil, queue: nil) { _ in self.saveApplicationState() }
     }
@@ -293,10 +294,6 @@ final class AppCoordinator {
         Preferences.shared.selectedScheduleItemIdentifier = selectedScheduleItemValue?.identifier
         Preferences.shared.selectedVideoItemIdentifier = selectedSessionValue?.identifier
         Preferences.shared.filtersState = searchCoordinator.currentFiltersState()
-    }
-
-    private func restoreApplicationState() {
-        tabController.activeTab = Preferences.shared.activeTab
     }
 
     private func restoreListStatesIfNeeded() {

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -193,8 +193,6 @@ class SessionsTableViewController: NSViewController {
         selectSession(with: identifier, scrollOnly: true)
     }
 
-    private var setupDone = false
-
     override func viewDidAppear() {
         super.viewDidAppear()
 
@@ -205,15 +203,21 @@ class SessionsTableViewController: NSViewController {
         searchController.searchField.isEnabled = true
     }
 
+    /// Variable used to track whether the initial display of rows has occurred
+    /// - warning: Not meant to be used outside of `performFirstUpdateIfNeeded`
+    private var setupDone = false
+
+    /// This function is meant to ensure the table view gets populated
+    /// even if its data model gets added while it is offscreen. Specifically,
+    /// when this table view is not the initial active tab.
     private func performFirstUpdateIfNeeded() {
+        guard !setupDone else { return }
+        setupDone = true
+
         switch style {
         case .schedule:
             updateScheduleList()
-            setupDone = true
         case .videos:
-            guard !setupDone else { return }
-            setupDone = true
-
             updateVideosList()
         }
     }

--- a/WWDC/WWDCTabViewController.swift
+++ b/WWDC/WWDCTabViewController.swift
@@ -10,10 +10,6 @@ import Cocoa
 import RxSwift
 import RxCocoa
 
-extension Notification.Name {
-    static let WWDCTabViewControllerDidFinishLoading = Notification.Name("WWDCTabViewControllerDidFinishLoading")
-}
-
 class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Tab.RawValue == Int {
 
     var activeTab: Tab {
@@ -75,34 +71,19 @@ class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Ta
         view.wantsLayer = true
     }
 
-    private var sentStatupNotification = false
-
-    private var isConfigured = false
-
-    override func viewDidAppear() {
-        super.viewDidAppear()
-
-        configureIfNeeded()
-    }
-
-    private func configureIfNeeded() {
-        guard !isConfigured else { return }
-
-        guard let toolbar = view.window?.toolbar else { return }
-
-        isConfigured = true
-
-        toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: 0)
-        toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: toolbar.items.count)
-
-        if !sentStatupNotification {
-            sentStatupNotification = true
-            NotificationCenter.default.post(name: .WWDCTabViewControllerDidFinishLoading, object: self)
-        }
-    }
-
     private func tabItem(with identifier: String) -> NSTabViewItem? {
         return tabViewItems.first { $0.identifier as? String == identifier }
+    }
+
+    override func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+
+        // Center the tab bar's NSToolbarItem's be putting flexible space at the beginning and end of
+        // the array. Super's implementation returns the NSToolbarItems that represent the NSTabViewItems
+        var defaultItemIdentifiers = super.toolbarDefaultItemIdentifiers(toolbar)
+        defaultItemIdentifiers.insert(.flexibleSpace, at: 0)
+        defaultItemIdentifiers.append(.flexibleSpace)
+
+        return defaultItemIdentifiers
     }
 
     override func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {


### PR DESCRIPTION
During my investigation into applying restored filters during the initial load of data rather than after, I found this problem.

1. Quit the app with the videos tab selected so that it is now the saved tab
2. Relaunch the app

At this point, `viewDidAppear` will be called on both tabs even though the schedule tab isn't selected. Additionally, `viewDidAppear` will never be called again for the schedule tab.

I tracked the root of problem down to setting the active tab within the execution context of `viewDidAppear` on `WWDCTabViewController` which was being caused by the firing of the **WWDCTabViewControllerDidFinishLoading** notification. Dispatching the notification asynchronously fixed the problem, but I was curious why the notification mechanism existed in the first place.

It seems it was in use to facilitate centering the toolbar items, so I did some research and found that as of 10.10 the preferred way of doing stuff like this is to override [`toolbarDefaultItemIdentifiers(:)`](https://developer.apple.com/documentation/appkit/nstabviewcontroller/1428251-toolbardefaultitemidentifiers).

> For example, include flexibleSpace strings as the first and last elements of the array to center the remaining toolbar items.

Once I found that, I was able to remove the notification altogether!