### PR TITLE
Apply restored search settings during intialization and other fixes

### DIFF
--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		01B3EB4A1EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B3EB491EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift */; };
 		3A0840B41F924665002BC828 /* Realm+InMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0840B31F924665002BC828 /* Realm+InMemory.swift */; };
 		3A6227031F9272A300D5F687 /* contents.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A6227021F9272A300D5F687 /* contents.json */; };
+		4D5EB0F820598E6000D4BC52 /* SessionRowProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */; };
 		4DEEC3A32051C8D400376595 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEEC3A22051C8D400376595 /* TestUtilities.swift */; };
 		DD0159A71ECFE26200F980F1 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A61ECFE26200F980F1 /* DeepLink.swift */; };
 		DD0159A91ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */; };
@@ -359,6 +360,7 @@
 		01B3EB491EEDD23100DE1003 /* AppCoordinator+SessionTableViewContextMenuActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+SessionTableViewContextMenuActions.swift"; sourceTree = "<group>"; };
 		3A0840B31F924665002BC828 /* Realm+InMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Realm+InMemory.swift"; sourceTree = "<group>"; };
 		3A6227021F9272A300D5F687 /* contents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = contents.json; sourceTree = "<group>"; };
+		4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowProvider.swift; sourceTree = "<group>"; };
 		4DEEC3A22051C8D400376595 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		DD0159A61ECFE26200F980F1 /* DeepLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+Bookmarks.swift"; sourceTree = "<group>"; };
@@ -1020,6 +1022,7 @@
 			children = (
 				DD36A4B11E478C6A00B2EA88 /* SessionsSplitViewController.swift */,
 				DD7F38611EABD6CF002D8C00 /* SessionsTableViewController.swift */,
+				4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */,
 				DDEA85F81EB52AA6002AE0EB /* Playback */,
 				DDFA10C71EBFD897001DCF66 /* Detail */,
 			);
@@ -1859,6 +1862,7 @@
 				DDF32EB31EBE5C4D0028E39D /* SessionActionsViewController.swift in Sources */,
 				DD7F38761EABFB20002D8C00 /* NSColor+Hex.swift in Sources */,
 				DDB28F931EAD48D70077703F /* UserActivityRepresentable.swift in Sources */,
+				4D5EB0F820598E6000D4BC52 /* SessionRowProvider.swift in Sources */,
 				DDEDFCF11ED927A4002477C8 /* ToggleFilter.swift in Sources */,
 				DD7F38801EAC15B4002D8C00 /* RxNil.swift in Sources */,
 				DDFA10BF1EBEAAAD001DCF66 /* DownloadManager.swift in Sources */,

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -284,8 +284,12 @@ final class AppCoordinator {
 
     private func saveApplicationState() {
         Preferences.shared.activeTab = activeTab
-        Preferences.shared.selectedScheduleItemIdentifier = selectedScheduleItemValue?.identifier
-        Preferences.shared.selectedVideoItemIdentifier = selectedSessionValue?.identifier
+        if let identifier = selectedScheduleItemValue?.identifier {
+            Preferences.shared.selectedScheduleItemIdentifier = identifier
+        }
+        if let identifier = selectedSessionValue?.identifier {
+            Preferences.shared.selectedVideoItemIdentifier = identifier
+        }
         Preferences.shared.filtersState = searchCoordinator.currentFiltersState()
     }
 

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -66,6 +66,10 @@ final class AppCoordinator {
 
         DownloadManager.shared.start(with: storage)
 
+        liveObserver = LiveObserver(dateProvider: today, storage: storage)
+
+        // Primary UI Intialization
+
         tabController = WWDCTabViewController(windowController: windowController)
 
         // Schedule
@@ -86,11 +90,9 @@ final class AppCoordinator {
         videosItem.label = "Videos"
         tabController.addTabViewItem(videosItem)
 
-        tabController.activeTab = Preferences.shared.activeTab
-
         self.windowController = windowController
 
-        liveObserver = LiveObserver(dateProvider: today, storage: storage)
+        restoreApplicationState()
 
         setupBindings()
         setupDelegation()
@@ -138,6 +140,7 @@ final class AppCoordinator {
 
     private func setupBindings() {
         tabController.rxActiveTab.subscribe(onNext: { [weak self] activeTab in
+
             self?.activeTab = activeTab
 
             self?.updateSelectedViewModelRegardlessOfTab()
@@ -202,20 +205,23 @@ final class AppCoordinator {
         storage.tracksObservable
             .take(1)
             .subscribe(onNext: { [weak self] tracks in
-                self?.videosController.listViewController.tracks = tracks
+                // Currently these two things must happen together and in this order for
+                // new information to be displayed. It's not ideal
+                self?.videosController.listViewController.sessionRowProvider = VideosSessionRowProvider(tracks: tracks)
+                self?.searchCoordinator.applyVideosFilters()
             }).disposed(by: disposeBag)
 
         storage.scheduleObservable
             .take(1)
             .subscribe(onNext: { [weak self] sections in
-                self?.scheduleController.listViewController.scheduleSections = sections
+                // Currently these two things must happen together and in this order for
+                // new information to be displayed. It's not ideal
+                self?.scheduleController.listViewController.sessionRowProvider = ScheduleSessionRowProvider(scheduleSections: sections)
+                self?.scrollToTodayIfWWDC()
+                self?.searchCoordinator.applyScheduleFilters()
             }).disposed(by: disposeBag)
 
         liveObserver.start()
-
-        restoreListStatesIfNeeded()
-
-        setupSearch()
     }
 
     private lazy var searchCoordinator: SearchCoordinator = {
@@ -224,10 +230,6 @@ final class AppCoordinator {
                                  videosController: self.videosController.listViewController,
                                  restorationFiltersState: Preferences.shared.filtersState)
     }()
-
-    private func setupSearch() {
-        searchCoordinator.configureFilters()
-    }
 
     private func startup() {
         RemoteEnvironment.shared.start()
@@ -280,10 +282,6 @@ final class AppCoordinator {
 
     // MARK: - State restoration
 
-    private var didRestoreLists = false
-
-    private var deferredLink: DeepLink?
-
     private func saveApplicationState() {
         Preferences.shared.activeTab = activeTab
         Preferences.shared.selectedScheduleItemIdentifier = selectedScheduleItemValue?.identifier
@@ -291,48 +289,37 @@ final class AppCoordinator {
         Preferences.shared.filtersState = searchCoordinator.currentFiltersState()
     }
 
-    private func restoreListStatesIfNeeded() {
-        defer { didRestoreLists = true }
+    private func restoreApplicationState() {
 
-        if let link = deferredLink {
-            return handle(link: link)
-        }
+        searchCoordinator.restoreSavedFilters()
+        let activeTab = Preferences.shared.activeTab
+        tabController.activeTab = activeTab
 
-        guard !didRestoreLists else { return }
-
-        if !scrollToToday() {
-            if let identifier = Preferences.shared.selectedScheduleItemIdentifier {
-                scheduleController.listViewController.selectSession(with: identifier)
-            }
+        if let identifier = Preferences.shared.selectedScheduleItemIdentifier {
+            scheduleController.listViewController.selectSession(with: identifier, deferIfNeeded: true)
         }
 
         if let identifier = Preferences.shared.selectedVideoItemIdentifier {
-            videosController.listViewController.selectSession(with: identifier)
+            videosController.listViewController.selectSession(with: identifier, deferIfNeeded: true)
         }
     }
 
-    private func scrollToToday() -> Bool {
-        guard liveObserver.isWWDCWeek else { return false }
+    private func scrollToTodayIfWWDC() {
+        guard liveObserver.isWWDCWeek else { return }
 
         scheduleController.listViewController.scrollToToday()
-
-        return true
     }
 
     // MARK: - Deep linking
 
-    func handle(link: DeepLink) {
-        guard didRestoreLists else {
-            deferredLink = link
-            return
-        }
+    func handle(link: DeepLink, deferIfNeeded: Bool) {
 
         if link.isForCurrentYear {
             tabController.activeTab = .schedule
-            scheduleController.listViewController.selectSession(with: link.sessionIdentifier)
+            scheduleController.listViewController.selectSession(with: link.sessionIdentifier, deferIfNeeded: true)
         } else {
             tabController.activeTab = .videos
-            videosController.listViewController.selectSession(with: link.sessionIdentifier)
+            videosController.listViewController.selectSession(with: link.sessionIdentifier, deferIfNeeded: true)
         }
     }
 

--- a/WWDC/AppDelegate.swift
+++ b/WWDC/AppDelegate.swift
@@ -44,7 +44,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard let url = URL(string: urlString) else { return }
         guard let link = DeepLink(url: url) else { return }
 
-        coordinator.handle(link: link)
+        coordinator.handle(link: link, deferIfNeeded: true)
     }
 
     @IBAction func showPreferences(_ sender: Any) {

--- a/WWDC/Arguments.swift
+++ b/WWDC/Arguments.swift
@@ -32,6 +32,8 @@ struct Arguments {
 
     static var deloreanDate: String? {
         guard let deloreanIndex = args.index(of: "--delorean") else { return nil }
+        // An example value: 2017-06-07'T'12:00:00-06:00
+        // - see: `DateProvider`
 
         guard args.count > deloreanIndex + 1 else { return nil }
 

--- a/WWDC/LiveObserver.swift
+++ b/WWDC/LiveObserver.swift
@@ -55,7 +55,10 @@ final class LiveObserver {
         NSLog("Live event observer started")
 
         backgroundActivity.schedule { [weak self] completion in
-            self?.checkForLiveSessions()
+            // Because of Realm
+            DispatchQueue.main.async {
+                self?.checkForLiveSessions()
+            }
         }
     }
 

--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -54,7 +54,7 @@ final class SearchCoordinator {
                                                object: nil)
     }
 
-    func configureFilters() {
+    func restoreSavedFilters() {
 
         // Schedule Filters Configuration
 
@@ -131,11 +131,6 @@ final class SearchCoordinator {
 
         if !scheduleSearchController.filters.isIdentical(to: scheduleSearchFilters) {
             scheduleSearchController.filters = scheduleSearchFilters
-
-            let activeScheduleFilters = scheduleSearchFilters.filter { !$0.isEmpty }
-            if activeScheduleFilters.count > 0 {
-                updateSearchResults(for: scheduleController, with: activeScheduleFilters)
-            }
         }
 
         // Videos Filter Configuration
@@ -179,16 +174,19 @@ final class SearchCoordinator {
 
         if !videosSearchController.filters.isIdentical(to: videosSearchFilters) {
             videosSearchController.filters = videosSearchFilters
-
-            let activeVideosFilters = videosSearchFilters.filter { !$0.isEmpty }
-            if activeVideosFilters.count > 0 {
-                updateSearchResults(for: videosController, with: activeVideosFilters)
-            }
         }
 
         // set delegates
         scheduleSearchController.delegate = self
         videosSearchController.delegate = self
+    }
+
+    func applyScheduleFilters() {
+        updateSearchResults(for: scheduleController, with: scheduleSearchController.filters)
+    }
+
+    func applyVideosFilters() {
+        updateSearchResults(for: videosController, with: videosSearchController.filters)
     }
 
     fileprivate lazy var searchQueue: DispatchQueue = DispatchQueue(label: "Search", qos: .userInteractive)

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -19,8 +19,7 @@ class SessionDetailsViewController: NSViewController {
     var viewModel: SessionViewModel? = nil {
         didSet {
 
-            informationStackView.animator().isHidden = (viewModel == nil)
-            shelfController.view.animator().isHidden = (viewModel == nil)
+            view.animator().alphaValue = (viewModel == nil) ? 0 : 1
 
             shelfController.viewModel = viewModel
             summaryController.viewModel = viewModel
@@ -47,10 +46,12 @@ class SessionDetailsViewController: NSViewController {
 
             shelfController.view.isHidden = sessionHasNoVideo
 
-            // Connect stack view (bottom half of screen), to the top of the view
-            // or to the bottom of the video, if it's present
+            // It's worth noting that this condition will always be true since the view
+            // gets loaded when add to the split view controller
             if isViewLoaded {
 
+                // Connect stack view (bottom half of screen), to the top of the view
+                // or to the bottom of the video, if it's present
                 shelfBottomConstraint.isActive = !sessionHasNoVideo
                 informationStackViewTopConstraint.isActive = sessionHasNoVideo
                 informationStackViewBottomConstraint.isActive = !sessionHasNoVideo
@@ -208,10 +209,6 @@ class SessionDetailsViewController: NSViewController {
         informationStackViewTopConstraint.isActive = false
 
         showOverview()
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
     }
 
     @objc private func tabButtonAction(_ sender: WWDCTextButton) {

--- a/WWDC/SessionRow.swift
+++ b/WWDC/SessionRow.swift
@@ -41,14 +41,29 @@ final class SessionRow: CustomDebugStringConvertible {
     }
 }
 
-extension SessionRow: Hashable {
+extension SessionRow: Equatable {
 
     var hashValue: Int {
-        return ObjectIdentifier(self).hashValue
+        let caseNameStringHash = String(reflecting: kind).hashValue
+        switch kind {
+        case let .sectionHeader(title):
+            return caseNameStringHash ^ title.hashValue
+        case let .session(viewModel):
+            return caseNameStringHash ^ viewModel.identifier.hashValue
+        }
     }
 
+    /// This definition of equality of 2 rows depends largely on the fact that
+    /// each view is bound to a realm object so there is no need to create a new row
     static func == (lhs: SessionRow, rhs: SessionRow) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        switch (lhs.kind, rhs.kind) {
+        case let (.sectionHeader(lhsTitle), .sectionHeader(rhsTitle)) where lhsTitle == rhsTitle:
+            return true
+        case let (.session(lhsViewModel), .session(rhsViewModel)) where lhsViewModel.identifier == rhsViewModel.identifier:
+            return true
+        default:
+            return false
+        }
     }
 }
 

--- a/WWDC/SessionRowProvider.swift
+++ b/WWDC/SessionRowProvider.swift
@@ -1,0 +1,89 @@
+//
+//  SessionRowProvider.swift
+//  WWDC
+//
+//  Created by Allen Humphreys on 3/14/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import ConfCore
+import RealmSwift
+
+protocol SessionRowProvider {
+    func sessionRowIdentifierForToday() -> String?
+    func sessionRows() -> [SessionRow]
+
+    var sessionSortingFunction: (Session, Session) -> Bool { get }
+}
+
+struct VideosSessionRowProvider: SessionRowProvider {
+
+    var tracks: Results<Track>
+
+    var sessionSortingFunction: (Session, Session) -> Bool {
+        return Session.standardSort
+    }
+
+    func sessionRows() -> [SessionRow] {
+
+        let rows: [SessionRow] = tracks.flatMap { track -> [SessionRow] in
+            let titleRow = SessionRow(title: track.name)
+
+            let sessionRows: [SessionRow] = track.sessions.filter(Session.videoPredicate).sorted(by: Session.standardSort).flatMap { session in
+                guard let viewModel = SessionViewModel(session: session) else { return nil }
+
+                return SessionRow(viewModel: viewModel)
+            }
+
+            return [titleRow] + sessionRows
+        }
+
+        return rows
+    }
+
+    func sessionRowIdentifierForToday() -> String? {
+        return nil
+    }
+}
+
+struct ScheduleSessionRowProvider: SessionRowProvider {
+
+    var scheduleSections: Results<ScheduleSection>
+
+    var sessionSortingFunction: (Session, Session) -> Bool {
+        return Session.standardSortForSchedule
+    }
+
+    func sessionRows() -> [SessionRow] {
+
+        // Only show the timezone on the first section header
+        var shownTimeZone = false
+
+        let rows: [SessionRow] = scheduleSections.flatMap { section -> [SessionRow] in
+
+            // Section header
+            let titleRow = SessionRow(date: section.representedDate, showTimeZone: !shownTimeZone)
+
+            shownTimeZone = true
+
+            let instanceRows: [SessionRow] = section.instances.sorted(by: SessionInstance.standardSort).flatMap { instance in
+                guard let viewModel = SessionViewModel(session: instance.session, instance: instance, style: .schedule) else { return nil }
+
+                return SessionRow(viewModel: viewModel)
+            }
+
+            return [titleRow] + instanceRows
+        }
+
+        return rows
+    }
+
+    func sessionRowIdentifierForToday() -> String? {
+
+        guard let section = scheduleSections.filter("representedDate >= %@", today()).first else { return nil }
+
+        guard let identifier = section.instances.first?.session?.identifier else { return nil }
+
+        return identifier
+    }
+}

--- a/WWDC/SessionTableCellView.swift
+++ b/WWDC/SessionTableCellView.swift
@@ -18,11 +18,8 @@ final class SessionTableCellView: NSTableCellView {
         didSet {
             guard viewModel !== oldValue else { return }
 
-            DispatchQueue.main.async {
-                self.thumbnailImageView.image = #imageLiteral(resourceName: "noimage")
-
-                self.bindUI()
-            }
+            thumbnailImageView.image = #imageLiteral(resourceName: "noimage")
+            bindUI()
         }
     }
 

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -158,7 +158,7 @@ class SessionsTableViewController: NSViewController {
                 context.completionHandler = {
                     NSAnimationContext.runAnimationGroup({ (context) in
                         context.allowsImplicitAnimation = true
-                        self.tableView.scrollRowToVisible(selectedIndexes.first ?? 0)
+                        self.tableView.scrollRowToCenter(selectedIndexes.first ?? 0)
                     }, completionHandler: nil)
                 }
 
@@ -213,7 +213,7 @@ class SessionsTableViewController: NSViewController {
             return
         }
 
-        tableView.scrollRowToVisible(index)
+        tableView.scrollRowToCenter(index)
 
         if !scrollOnly {
             tableView.selectRowIndexes(IndexSet([index]), byExtendingSelection: false)

--- a/WWDC/WWDCTabViewController.swift
+++ b/WWDC/WWDCTabViewController.swift
@@ -65,14 +65,25 @@ class WWDCTabViewController<Tab: RawRepresentable>: NSTabViewController where Ta
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        transitionOptions = .allowUserInteraction
-
         tabStyle = .toolbar
         view.wantsLayer = true
     }
 
     private func tabItem(with identifier: String) -> NSTabViewItem? {
         return tabViewItems.first { $0.identifier as? String == identifier }
+    }
+
+    override func transition(from fromViewController: NSViewController, to toViewController: NSViewController, options: NSViewController.TransitionOptions = [], completionHandler completion: (() -> Void)? = nil) {
+
+        // Disable the crossfade animation here instead of removing it from the transition options
+        // This works around a bug in NSSearchField in which the animation of resigning first responder
+        // would get stuck if you switched tabs while the search field was first responder. Upon returning
+        // to the original tab, you would see the search field's placeholder animate back to center
+        // search_field_responder_tag
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0
+            super.transition(from: fromViewController, to: toViewController, options: options, completionHandler: completion)
+        })
     }
 
     override func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {

--- a/WWDC/WWDCTableView.swift
+++ b/WWDC/WWDCTableView.swift
@@ -38,3 +38,30 @@ class WWDCTableView: NSTableView {
         return super.menu(for: event)
     }
 }
+
+extension NSTableView {
+
+    func scrollRowToCenter(_ row: Int) {
+
+        guard let clipView = superview as? NSClipView,
+              let scrollView = clipView.superview as? NSScrollView else {
+
+                assertionFailure("Unexpected NSTableView view hiearchy")
+                return
+        }
+
+        let rowRect = rect(ofRow: row)
+        var scrollOrigin = rowRect.origin
+
+        let tableHalfHeight = clipView.frame.height * 0.5
+        let rowRectHalfHeight = rowRect.height * 0.5
+
+        scrollOrigin.y = (scrollOrigin.y - tableHalfHeight) + rowRectHalfHeight
+
+        if scrollView.responds(to: #selector(NSScrollView.flashScrollers)) {
+            scrollView.flashScrollers()
+        }
+
+        clipView.setBoundsOrigin(scrollOrigin)
+    }
+}

--- a/WWDC/WWDCWindow.swift
+++ b/WWDC/WWDCWindow.swift
@@ -52,4 +52,22 @@ class WWDCWindow: NSWindow {
         titlebarView?.layer?.backgroundColor = NSColor.darkTitlebarBackground.cgColor
     }
 
+    override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+
+        // Prevent NSSearchField in the filters controller from becoming the first responder automatically
+        // search_field_responder_tag
+        if let event = currentEvent,
+            let searchField = responder as? NSSearchField {
+
+            let pointInView = searchField.convert(event.locationInWindow, from: nil)
+            if !searchField.mouse(pointInView, in: searchField.bounds) {
+                return false
+            }
+        } else if currentEvent == nil {
+            // Prevents automatic state restoration
+            return false
+        }
+
+        return super.makeFirstResponder(responder)
+    }
 }


### PR DESCRIPTION
* Fixes #355 - selection restoration
* Applies the saved filters during app startup's initial displaying of data, avoiding the ugly animation
* Fixes the flickering behavior of the search fields by reworking how we prevent them from automatically becoming first responder (previously we were setting the first responder to nil when the `SessionsTableViewController` appeared sometimes resulting in seeing parts of the search fields animations)
* Simplifies list restoration by moving deferral into `SessionsTableViewController` so it can handle its own initialization
* Hides all UI initialization, animating the `alphaValue` up when the list has been initialized. No scrolling should be visible, though some thumbnails may appear to load after the table is visible
* Simplifies `SessionsTableViewController` by creating `SessionRowProvider` to abstract away the fact that SessionsTableViewController was actually doing 2 different jobs
* Fixes app crashes during WWDC week caused by #356 
* When performing automatic scrolling during search and state restoration, the row will now be centered in the table if possible

Things I Tested:
* Behavior of fresh install by using `cleardata.sh`
* Deeplink handling both when the app is running and when the app gets launched
* During WWDC using --delorean