### PR TITLE
Fixes filter initialization on fresh install

### DIFF
--- a/ConfCore/Storage.swift
+++ b/ConfCore/Storage.swift
@@ -388,6 +388,18 @@ public final class Storage {
         }
     }
 
+    public lazy var eventsObservable: Observable<Results<Event>> = {
+        let events = realm.objects(Event.self).sorted(byKeyPath: "startDate", ascending: false)
+
+        return Observable.collection(from: events)
+    }()
+
+    public lazy var focusesObservable: Observable<Results<Focus>> = {
+        let focuses = realm.objects(Focus.self).sorted(byKeyPath: "name")
+
+        return Observable.collection(from: focuses)
+    }()
+
     public lazy var tracksObservable: Observable<Results<Track>> = {
         let tracks = self.realm.objects(Track.self).sorted(byKeyPath: "order")
 

--- a/WWDC/FilterType.swift
+++ b/WWDC/FilterType.swift
@@ -68,7 +68,14 @@ extension Array where Element == FilterType {
 
             for filter in self {
 
-                if !otherArray.contains(where: { $0.identifier == filter.identifier }) {
+                if !otherArray.contains(where: {
+                    if let mc0 = $0 as? MultipleChoiceFilter, let mc1 = filter as? MultipleChoiceFilter {
+                        return mc0.identifier == mc1.identifier && mc0.options == mc1.options
+                    } else {
+                        return $0.identifier == filter.identifier
+                    }
+
+                }) {
                     isIdentical = false
                     break
                 }

--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -54,7 +54,7 @@ final class SearchCoordinator {
                                                object: nil)
     }
 
-    func restoreSavedFilters() {
+    func configureFilters() {
 
         // Schedule Filters Configuration
 


### PR DESCRIPTION
It turns out I missed something 😅

On a fresh install the filters couldn't be built because I wasn't waiting for all the requisite items to be synced into realm. This fixes that and broadens the scope of when the loading view gets hidden so that the filters can be guaranteed to be set up correctly before removing the loading. I could change the definition of `isEmpty` to also reflect the logic in the combined observable.

I combined the schedule and videos tabs observables to provide a guaranteed order of < filter configuration > -> < list setup > -> < filter results applied >