### PR TITLE
Fixes several image downloader bugs

### DIFF
--- a/WWDC/SessionTableCellView.swift
+++ b/WWDC/SessionTableCellView.swift
@@ -23,7 +23,7 @@ final class SessionTableCellView: NSTableCellView {
         }
     }
 
-    private var imageDownloadOperation: Operation?
+    private weak var imageDownloadOperation: Operation?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -75,7 +75,7 @@ class ShelfViewController: NSViewController {
         updateBindings()
     }
 
-    private var currentImageDownloadOperation: Operation?
+    private weak var currentImageDownloadOperation: Operation?
 
     private func updateBindings() {
         disposeBag = DisposeBag()


### PR DESCRIPTION
 - Cancelled tasks remaining in the queue because of failure to set `_executing` to false
 - Failing to add new image operations to the queue because not checking `isCancelled` when determining whether an operation already exists
 - Only request the thumbnail from the cache for session cells [optimization]

After fixing the clear data script I found that there were some issues re-surfaced regarding the image loading. The case I was testing was performing filters with an empty case state and other intense tasks such as scrolling quickly through the entire list. 

What I found was that operations were getting stuck in the queue because they were checking for `isCancelled` and exiting but not letting the operation queue know they are done via KVO by updating their `_executing` property. This was high priority as images would remain "missing" until the app is relaunched.

Another case was that a cell could call cancel on its operation but before the operation completed its cancelation another cell could try to start an operation for the same URL but be silently rejected as the `hasActiveOperation` was not checking the `isCancelled` property.

There is still an outstanding issue. 

Essentially if 2 actors (session cell and the shelf) try to access an image by URL at (roughly) the same time, the second one will be ignored by the guard. I added a log statement to show this happening. The main time this happens is when a session is selected, so it's really easy to reproduce if you clear your cache and then just key down to scroll through the table, you'll end up with many cells that don't have thumbnails. This issue has a work around, though, as then next time the session is scrolled into view it will get the cached thumbnails.