### PR TITLE
Fixes incorrect behavior of session context menu

### DIFF
--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -100,7 +100,7 @@ final class SearchCoordinator {
                                                     isOn: false,
                                                     customPredicate: downloadedPredicate)
 
-        let smallPositionPred = NSPredicate(format: "SUBQUERY(progresses, $progress, $progress.relativePosition < 0.9).@count > 0")
+        let smallPositionPred = NSPredicate(format: "SUBQUERY(progresses, $progress, $progress.relativePosition < \(Constants.watchedVideoRelativePosition)).@count > 0")
         let noPositionPred = NSPredicate(format: "progresses.@count == 0")
 
         let unwatchedPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [smallPositionPred, noPositionPred])

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -471,9 +471,13 @@ class SessionsTableViewController: NSViewController {
 
         switch menuItem.option {
         case .watched:
-            return viewModel.session.progresses.first == nil || viewModel.session.progresses.first?.relativePosition != 1
+            let canMarkAsWatched = !viewModel.session.isWatched
+                && viewModel.session.instances.first?.isCurrentlyLive != true
+                && viewModel.session.asset(of: .streamingVideo) != nil
+
+            return canMarkAsWatched
         case .unwatched:
-            return viewModel.session.progresses.first?.relativePosition == 1
+            return viewModel.session.isWatched
         case .favorite:
             return !viewModel.isFavorite
         case .removeFavorite:
@@ -491,6 +495,17 @@ class SessionsTableViewController: NSViewController {
         case let (.revealInFinder, remoteURL?):
             return DownloadManager.shared.hasVideo(remoteURL)
         default: ()
+        }
+
+        return false
+    }
+}
+
+extension Session {
+
+    var isWatched: Bool {
+        if let progress = progresses.first {
+            return progress.relativePosition > Constants.watchedVideoRelativePosition
         }
 
         return false


### PR DESCRIPTION
Fixes #347 

It turns out there was a constant already defined, it's value is 0.97. 