### PR TITLE
Narrows the scope of the ATS disabling

### DIFF
--- a/TranscriptIndexingService/Info.plist
+++ b/TranscriptIndexingService/Info.plist
@@ -10,8 +10,14 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>asciiwwdc.com</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/WWDC/Info.plist
+++ b/WWDC/Info.plist
@@ -61,16 +61,18 @@
 	<string>Guilherme Rambo</string>
 	<key>GRBundleMainDeveloperWebsite</key>
 	<string>https://twitter.com/_inside</string>
-	<key>GRBundleUserInterfaceCreatorWebsite</key>
-	<string>https://twitter.com/VicenteBorrell</string>
 	<key>GRBundleRepositoryName</key>
 	<string>insidegui/WWDC</string>
 	<key>GRBundleRepositoryWebsite</key>
 	<string>https://github.com/insidegui/WWDC</string>
+	<key>GRBundleUserInterfaceCreatorWebsite</key>
+	<string>https://twitter.com/VicenteBorrell</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSAllowsArbitraryLoadsForMedia</key>
+		<true/>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>

--- a/WWDC/Info.plist
+++ b/WWDC/Info.plist
@@ -71,7 +71,7 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
As far as I could tell, the only exceptions for ATS are the test environment "http://localhost:9042" which is covered by `NSAllowsLocalNetworking` and `asciiwwdc.com` which is given an explicit exception via `NSExceptionDomains`. 