### PR TITLE
"Now Playing" widget and remote command support

### DIFF
--- a/PlayerUI/Definitions/Speeds.swift
+++ b/PlayerUI/Definitions/Speeds.swift
@@ -19,6 +19,10 @@ public enum PUIPlaybackSpeed: Float {
         return [.slow, .normal, .midFast, .fast, .fastest]
     }
 
+    static var supportedPlaybackRates: [NSNumber] {
+        return all.map { NSNumber(value : $0.rawValue) }
+    }
+
     var icon: NSImage {
         switch self {
         case .slow:

--- a/PlayerUI/MediaPlayer Support/PUINowPlayingInfo.swift
+++ b/PlayerUI/MediaPlayer Support/PUINowPlayingInfo.swift
@@ -14,11 +14,13 @@ public struct PUINowPlayingInfo {
     public var title: String
     public var artist: String
     public var progress: Double
+    public var isLive: Bool
 
-    public init(title: String, artist: String, progress: Double = 0) {
+    public init(title: String, artist: String, progress: Double = 0, isLive: Bool = false) {
         self.title = title
         self.artist = artist
         self.progress = progress
+        self.isLive = isLive
     }
 
 }
@@ -33,6 +35,7 @@ extension PUINowPlayingInfo {
 
         if #available(OSX 10.12.2, *) {
             info[MPNowPlayingInfoPropertyPlaybackProgress] = progress
+            info[MPNowPlayingInfoPropertyIsLiveStream] = isLive
         }
 
         return info

--- a/PlayerUI/MediaPlayer Support/PUINowPlayingInfo.swift
+++ b/PlayerUI/MediaPlayer Support/PUINowPlayingInfo.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Guilherme Rambo. All rights reserved.
 //
 
-import Foundation
+import Cocoa
 import MediaPlayer
 
 public struct PUINowPlayingInfo {
@@ -15,12 +15,14 @@ public struct PUINowPlayingInfo {
     public var artist: String
     public var progress: Double
     public var isLive: Bool
+    public var image: NSImage?
 
-    public init(title: String, artist: String, progress: Double = 0, isLive: Bool = false) {
+    public init(title: String, artist: String, progress: Double = 0, isLive: Bool = false, image: NSImage? = nil) {
         self.title = title
         self.artist = artist
         self.progress = progress
         self.isLive = isLive
+        self.image = image
     }
 
 }
@@ -36,6 +38,10 @@ extension PUINowPlayingInfo {
         if #available(OSX 10.12.2, *) {
             info[MPNowPlayingInfoPropertyPlaybackProgress] = progress
             info[MPNowPlayingInfoPropertyIsLiveStream] = isLive
+        }
+
+        if #available(macOS 10.13.2, *), let image = self.image {
+            info[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(boundsSize: image.size, requestHandler: { _ in image })
         }
 
         return info

--- a/PlayerUI/MediaPlayer Support/PUINowPlayingInfo.swift
+++ b/PlayerUI/MediaPlayer Support/PUINowPlayingInfo.swift
@@ -1,0 +1,41 @@
+//
+//  PUINowPlayingInfo.swift
+//  PlayerUI
+//
+//  Created by Guilherme Rambo on 22/04/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Foundation
+import MediaPlayer
+
+public struct PUINowPlayingInfo {
+
+    public var title: String
+    public var artist: String
+    public var progress: Double
+
+    public init(title: String, artist: String, progress: Double = 0) {
+        self.title = title
+        self.artist = artist
+        self.progress = progress
+    }
+
+}
+
+extension PUINowPlayingInfo {
+
+    var dictionaryRepresentation: [String: Any] {
+        var info: [String: Any] = [
+            MPMediaItemPropertyTitle: title,
+            MPMediaItemPropertyArtist: artist
+        ]
+
+        if #available(OSX 10.12.2, *) {
+            info[MPNowPlayingInfoPropertyPlaybackProgress] = progress
+        }
+
+        return info
+    }
+
+}

--- a/PlayerUI/MediaPlayer Support/PUINowPlayingInfoCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUINowPlayingInfoCoordinator.swift
@@ -53,6 +53,10 @@ final class PUINowPlayingInfoCoordinator {
             info.merge(basicInfo, uniquingKeysWith: { a, b in b })
         }
 
+        if item.duration.isValid, item.duration.isNumeric {
+            info[MPMediaItemPropertyPlaybackDuration] = TimeInterval(CMTimeGetSeconds(item.duration))
+        }
+
         return info
     }
 

--- a/PlayerUI/MediaPlayer Support/PUINowPlayingInfoCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUINowPlayingInfoCoordinator.swift
@@ -36,13 +36,13 @@ final class PUINowPlayingInfoCoordinator {
         guard let item = player.currentItem else { return nil }
 
         var info: [String: Any] = [
-            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.video,
+            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.video.rawValue,
             MPNowPlayingInfoPropertyPlaybackRate: player.rate,
             MPNowPlayingInfoPropertyElapsedPlaybackTime: CMTimeGetSeconds(player.currentTime())
         ]
 
         if #available(macOS 10.12.3, *), let urlAsset = item.asset as? AVURLAsset {
-            info[MPNowPlayingInfoPropertyAssetURL] = urlAsset
+            info[MPNowPlayingInfoPropertyAssetURL] = urlAsset.url
         }
 
         if #available(macOS 10.13.1, *) {

--- a/PlayerUI/MediaPlayer Support/PUINowPlayingInfoCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUINowPlayingInfoCoordinator.swift
@@ -1,0 +1,100 @@
+//
+//  PUINowPlayingInfoCoordinator.swift
+//  PlayerUI
+//
+//  Created by Guilherme Rambo on 22/04/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Foundation
+import MediaPlayer
+
+final class PUINowPlayingInfoCoordinator {
+
+    let player: AVPlayer
+
+    @available(macOS 10.12.2, *)
+    init(player: AVPlayer) {
+        self.player = player
+
+        observePlayer()
+    }
+
+    var basicNowPlayingInfo: PUINowPlayingInfo?
+
+    // MARK: - Playback state
+
+    @available(macOS 10.12.2, *)
+    var playbackStateAppropriateForPlayer: MPNowPlayingPlaybackState {
+        return player.rate.isZero ? .paused : .playing
+    }
+
+    // MARK: - Playback info
+
+    @available(macOS 10.12.2, *)
+    var nowPlayingInfo: [String: Any]? {
+        guard let item = player.currentItem else { return nil }
+
+        var info: [String: Any] = [
+            MPNowPlayingInfoPropertyMediaType: MPNowPlayingInfoMediaType.video,
+            MPNowPlayingInfoPropertyPlaybackRate: player.rate,
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: CMTimeGetSeconds(player.currentTime())
+        ]
+
+        if #available(macOS 10.12.3, *), let urlAsset = item.asset as? AVURLAsset {
+            info[MPNowPlayingInfoPropertyAssetURL] = urlAsset
+        }
+
+        if #available(macOS 10.13.1, *) {
+            info[MPNowPlayingInfoPropertyCurrentPlaybackDate] = item.currentDate()
+        }
+
+        if let basicInfo = basicNowPlayingInfo?.dictionaryRepresentation {
+            info.merge(basicInfo, uniquingKeysWith: { a, b in b })
+        }
+
+        return info
+    }
+
+    // MARK: - Player observation
+
+    private var rateObservation: NSKeyValueObservation?
+    private var itemObservation: NSKeyValueObservation?
+    private var timeObserver: Any?
+
+    private func observePlayer() {
+        rateObservation = player.observe(\.rate) { [weak self] _, _ in
+            DispatchQueue.main.async { self?.playbackRateDidChange() }
+        }
+
+        itemObservation = player.observe(\.currentItem) { [weak self] _, _ in
+            DispatchQueue.main.async { self?.updateNowPlayingInfo() }
+        }
+
+        timeObserver = player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(1, 30000), queue: .main) { [weak self] _ in
+            DispatchQueue.main.async { self?.updateNowPlayingInfo() }
+        }
+    }
+
+    private func playbackRateDidChange() {
+        guard #available(macOS 10.12.2, *) else { return }
+
+        MPNowPlayingInfoCenter.default().playbackState = playbackStateAppropriateForPlayer
+    }
+
+    private func updateNowPlayingInfo() {
+        guard #available(macOS 10.12.2, *) else { return }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+
+    deinit {
+        if let timeObserver = timeObserver {
+            player.removeTimeObserver(timeObserver)
+        }
+
+        rateObservation?.invalidate()
+        itemObservation?.invalidate()
+    }
+
+}

--- a/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
@@ -35,13 +35,13 @@ final class PUIRemoteCommandCoordinator {
         }
     }
 
-    var skipForwardHandler: (() -> Void)? {
+    var nextTrackHandler: (() -> Void)? {
         didSet {
             updateCommandAvailability()
         }
     }
 
-    var skipBackwardHandler: (() -> Void)? {
+    var previousTrackHandler: (() -> Void)? {
         didSet {
             updateCommandAvailability()
         }
@@ -88,14 +88,14 @@ final class PUIRemoteCommandCoordinator {
             return .success
         }
 
-        center.skipForwardCommand.addTarget { [weak self] _ in
-            DispatchQueue.main.async { self?.skipForwardHandler?() }
+        center.nextTrackCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.nextTrackHandler?() }
 
             return .success
         }
 
-        center.skipBackwardCommand.addTarget { [weak self] _ in
-            DispatchQueue.main.async { self?.skipBackwardHandler?() }
+        center.previousTrackCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.previousTrackHandler?() }
 
             return .success
         }
@@ -126,12 +126,14 @@ final class PUIRemoteCommandCoordinator {
         center.playCommand.isEnabled = playHandler != nil
         center.stopCommand.isEnabled = stopHandler != nil
         center.togglePlayPauseCommand.isEnabled = togglePlayingHandler != nil
-        center.skipForwardCommand.isEnabled = skipForwardHandler != nil
-        center.skipBackwardCommand.isEnabled = skipBackwardHandler != nil
+        center.nextTrackCommand.isEnabled = nextTrackHandler != nil
+        center.previousTrackCommand.isEnabled = previousTrackHandler != nil
         center.likeCommand.isEnabled = likeHandler != nil
         center.changePlaybackPositionCommand.isEnabled = changePlaybackPositionHandler != nil
 
         // Unsupported commands
+        center.skipForwardCommand.isEnabled = false
+        center.skipBackwardCommand.isEnabled = false
         center.changePlaybackRateCommand.isEnabled = false
         center.ratingCommand.isEnabled = false
         center.dislikeCommand.isEnabled = false

--- a/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
@@ -9,7 +9,7 @@
 import Foundation
 import MediaPlayer
 
-final class PUIRemoteCommandCoordinator {
+final class PUIRemoteCommandCoordinator: NSObject {
 
     var pauseHandler: (() -> Void)? {
         didSet {
@@ -65,7 +65,9 @@ final class PUIRemoteCommandCoordinator {
         }
     }
 
-    init() {
+    override init() {
+        super.init()
+
         guard #available(macOS 10.12.2, *) else { return }
 
         let center = MPRemoteCommandCenter.shared()
@@ -134,6 +136,12 @@ final class PUIRemoteCommandCoordinator {
     }
 
     private func updateCommandAvailability() {
+        NSObject.cancelPreviousPerformRequests(withTarget: self)
+
+        perform(#selector(doUpdateCommandAvailability), with: nil, afterDelay: 0)
+    }
+
+    @objc private func doUpdateCommandAvailability() {
         guard #available(macOS 10.12.2, *) else { return }
 
         let center = MPRemoteCommandCenter.shared()

--- a/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
@@ -53,6 +53,12 @@ final class PUIRemoteCommandCoordinator {
         }
     }
 
+    var changePlaybackPositionHandler: ((TimeInterval) -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
     init() {
         guard #available(macOS 10.12.2, *) else { return }
 
@@ -100,6 +106,14 @@ final class PUIRemoteCommandCoordinator {
             return .success
         }
 
+        center.changePlaybackPositionCommand.addTarget { [weak self] event in
+            guard let effectiveEvent = event as? MPChangePlaybackPositionCommandEvent else { return .commandFailed }
+
+            self?.changePlaybackPositionHandler?(effectiveEvent.positionTime)
+
+            return .success
+        }
+
         updateCommandAvailability()
     }
 
@@ -115,10 +129,10 @@ final class PUIRemoteCommandCoordinator {
         center.skipForwardCommand.isEnabled = skipForwardHandler != nil
         center.skipBackwardCommand.isEnabled = skipBackwardHandler != nil
         center.likeCommand.isEnabled = likeHandler != nil
+        center.changePlaybackPositionCommand.isEnabled = changePlaybackPositionHandler != nil
 
         // Unsupported commands
         center.changePlaybackRateCommand.isEnabled = false
-        center.changePlaybackPositionCommand.isEnabled = false
         center.ratingCommand.isEnabled = false
         center.dislikeCommand.isEnabled = false
         center.nextTrackCommand.isEnabled = false

--- a/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
+++ b/PlayerUI/MediaPlayer Support/PUIRemoteCommandCoordinator.swift
@@ -1,0 +1,131 @@
+//
+//  PUIRemoteCommandCoordinator.swift
+//  PlayerUI
+//
+//  Created by Guilherme Rambo on 25/04/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Foundation
+import MediaPlayer
+
+final class PUIRemoteCommandCoordinator {
+
+    var pauseHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    var playHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    var stopHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    var togglePlayingHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    var skipForwardHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    var skipBackwardHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    var likeHandler: (() -> Void)? {
+        didSet {
+            updateCommandAvailability()
+        }
+    }
+
+    init() {
+        guard #available(macOS 10.12.2, *) else { return }
+
+        let center = MPRemoteCommandCenter.shared()
+
+        center.pauseCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.pauseHandler?() }
+
+            return .success
+        }
+
+        center.playCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.playHandler?() }
+
+            return .success
+        }
+
+        center.stopCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.stopHandler?() }
+
+            return .success
+        }
+
+        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.togglePlayingHandler?() }
+
+            return .success
+        }
+
+        center.skipForwardCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.skipForwardHandler?() }
+
+            return .success
+        }
+
+        center.skipBackwardCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.skipBackwardHandler?() }
+
+            return .success
+        }
+
+        center.likeCommand.addTarget { [weak self] _ in
+            DispatchQueue.main.async { self?.likeHandler?() }
+
+            return .success
+        }
+
+        updateCommandAvailability()
+    }
+
+    private func updateCommandAvailability() {
+        guard #available(macOS 10.12.2, *) else { return }
+
+        let center = MPRemoteCommandCenter.shared()
+
+        center.pauseCommand.isEnabled = pauseHandler != nil
+        center.playCommand.isEnabled = playHandler != nil
+        center.stopCommand.isEnabled = stopHandler != nil
+        center.togglePlayPauseCommand.isEnabled = togglePlayingHandler != nil
+        center.skipForwardCommand.isEnabled = skipForwardHandler != nil
+        center.skipBackwardCommand.isEnabled = skipBackwardHandler != nil
+        center.likeCommand.isEnabled = likeHandler != nil
+
+        // Unsupported commands
+        center.changePlaybackRateCommand.isEnabled = false
+        center.changePlaybackPositionCommand.isEnabled = false
+        center.ratingCommand.isEnabled = false
+        center.dislikeCommand.isEnabled = false
+        center.nextTrackCommand.isEnabled = false
+        center.previousTrackCommand.isEnabled = false
+        center.seekForwardCommand.isEnabled = false
+        center.seekBackwardCommand.isEnabled = false
+        center.bookmarkCommand.isEnabled = false
+    }
+
+}

--- a/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
+++ b/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
@@ -14,6 +14,7 @@ public protocol PUIPlayerViewDelegate: class {
     func playerViewWillExitPictureInPictureMode(_ playerView: PUIPlayerView, isReturningFromPiP: Bool)
     func playerViewDidSelectAddAnnotation(_ playerView: PUIPlayerView, at timestamp: Double)
     func playerViewDidSelectToggleFullScreen(_ playerView: PUIPlayerView)
+    func playerViewDidSelectLike(_ playerView: PUIPlayerView)
 
 }
 

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -249,6 +249,7 @@ public final class PUIPlayerView: NSView {
         }
 
         setupNowPlayingCoordinatorIfSupported()
+        setupRemoteCommandCoordinatorIfSupported()
     }
 
     private func teardown(player oldValue: AVPlayer) {
@@ -433,6 +434,40 @@ public final class PUIPlayerView: NSView {
 
         nowPlayingCoordinator = PUINowPlayingInfoCoordinator(player: player)
         nowPlayingCoordinator?.basicNowPlayingInfo = nowPlayingInfo
+    }
+
+    // MARK: - Remote command support (AirPlay 2)
+
+    private var remoteCommandCoordinator: PUIRemoteCommandCoordinator?
+
+    private func setupRemoteCommandCoordinatorIfSupported() {
+        guard #available(macOS 10.12.2, *) else { return }
+
+        remoteCommandCoordinator = PUIRemoteCommandCoordinator()
+
+        remoteCommandCoordinator?.pauseHandler = { [weak self] in
+            self?.pause(nil)
+        }
+        remoteCommandCoordinator?.playHandler = { [weak self] in
+            self?.play(nil)
+        }
+        remoteCommandCoordinator?.stopHandler = { [weak self] in
+            self?.pause(nil)
+        }
+        remoteCommandCoordinator?.togglePlayingHandler = { [weak self] in
+            self?.togglePlaying(nil)
+        }
+        remoteCommandCoordinator?.skipForwardHandler = { [weak self] in
+            self?.goForwardInTime15(nil)
+        }
+        remoteCommandCoordinator?.skipBackwardHandler = { [weak self] in
+            self?.goBackInTime15(nil)
+        }
+        remoteCommandCoordinator?.likeHandler = { [weak self] in
+            guard let `self` = self else { return }
+
+            self.delegate?.playerViewDidSelectLike(self)
+        }
     }
 
     // MARK: Controls

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -449,10 +449,10 @@ public final class PUIPlayerView: NSView {
         remoteCommandCoordinator?.togglePlayingHandler = { [weak self] in
             self?.togglePlaying(nil)
         }
-        remoteCommandCoordinator?.skipForwardHandler = { [weak self] in
+        remoteCommandCoordinator?.nextTrackHandler = { [weak self] in
             self?.goForwardInTime15(nil)
         }
-        remoteCommandCoordinator?.skipBackwardHandler = { [weak self] in
+        remoteCommandCoordinator?.previousTrackHandler = { [weak self] in
             self?.goBackInTime15(nil)
         }
         remoteCommandCoordinator?.likeHandler = { [weak self] in

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -463,6 +463,9 @@ public final class PUIPlayerView: NSView {
         remoteCommandCoordinator?.changePlaybackPositionHandler = { [weak self] time in
             self?.seek(to: time)
         }
+        remoteCommandCoordinator?.changePlaybackRateHandler = { [weak self] speed in
+            self?.playbackSpeed = speed
+        }
     }
 
     // MARK: Controls

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -139,15 +139,7 @@ public final class PUIPlayerView: NSView {
     }
 
     public func seek(to annotation: PUITimelineAnnotation) {
-        guard let player = player else { return }
-
-        let time = CMTimeMakeWithSeconds(Float64(annotation.timestamp), 9000)
-
-        if isPlayingExternally {
-            currentExternalPlaybackProvider?.seek(to: annotation.timestamp)
-        } else {
-            player.seek(to: time)
-        }
+        seek(to: annotation.timestamp)
     }
 
     public var playbackSpeed: PUIPlaybackSpeed = .normal {
@@ -467,6 +459,9 @@ public final class PUIPlayerView: NSView {
             guard let `self` = self else { return }
 
             self.delegate?.playerViewDidSelectLike(self)
+        }
+        remoteCommandCoordinator?.changePlaybackPositionHandler = { [weak self] time in
+            self?.seek(to: time)
         }
     }
 
@@ -965,12 +960,20 @@ public final class PUIPlayerView: NSView {
         let modifier = CMTimeMakeWithSeconds(seconds, durationTime.timescale)
         let targetTime = function(player.currentTime(), modifier)
 
-        guard targetTime.isValid && targetTime.isNumeric else { return }
+        seek(to: targetTime)
+    }
+
+    private func seek(to timestamp: TimeInterval) {
+        seek(to: CMTimeMakeWithSeconds(timestamp, 90000))
+    }
+
+    private func seek(to time: CMTime) {
+        guard time.isValid && time.isNumeric else { return }
 
         if isPlayingExternally {
-            currentExternalPlaybackProvider?.seek(to: seconds)
+            currentExternalPlaybackProvider?.seek(to: CMTimeGetSeconds(time))
         } else {
-            player.seek(to: targetTime)
+            player?.seek(to: time)
         }
     }
 

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -471,7 +471,6 @@ public final class PUIPlayerView: NSView {
 
     private var extrasMenuContainerView: NSStackView!
 
-    //    fileprivate var controlsVisualEffectView: NSVisualEffectView!
     fileprivate var scrimContainerView: PUIScrimContainerView!
 
     private var timeLabelsContainerView: NSStackView!
@@ -652,15 +651,6 @@ public final class PUIPlayerView: NSView {
         externalStatusController.view.topAnchor.constraint(equalTo: topAnchor).isActive = true
         externalStatusController.view.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
 
-        //        // VFX view
-        //        controlsVisualEffectView = NSVisualEffectView(frame: bounds)
-        //        controlsVisualEffectView.translatesAutoresizingMaskIntoConstraints = false
-        //        controlsVisualEffectView.material = .ultraDark
-        //        controlsVisualEffectView.appearance = NSAppearance(named: NSAppearanceNameVibrantDark)
-        //        controlsVisualEffectView.blendingMode = .withinWindow
-        //        controlsVisualEffectView.wantsLayer = true
-        //        controlsVisualEffectView.layer?.masksToBounds = false
-        //        controlsVisualEffectView.state = .active
         scrimContainerView = PUIScrimContainerView(frame: bounds)
 
         // Time labels

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		DDB352A01EC9088000254815 /* WWDCTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB3529F1EC9088000254815 /* WWDCTableView.swift */; };
 		DDB352A51EC90ACA00254815 /* TBProphylaxis.h in Headers */ = {isa = PBXBuildFile; fileRef = DDB352A31EC90ACA00254815 /* TBProphylaxis.h */; };
 		DDB352A61EC90ACA00254815 /* TBProphylaxis.m in Sources */ = {isa = PBXBuildFile; fileRef = DDB352A41EC90ACA00254815 /* TBProphylaxis.m */; };
+		DDBA0D79208D21BD0075670F /* PUINowPlayingInfoCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBA0D78208D21BD0075670F /* PUINowPlayingInfoCoordinator.swift */; };
+		DDBA0D7B208D3DE70075670F /* PUINowPlayingInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBA0D7A208D3DE70075670F /* PUINowPlayingInfo.swift */; };
 		DDC677ED1EDA6A3000A4E19C /* TranscriptIndexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC677EC1EDA6A3000A4E19C /* TranscriptIndexer.swift */; };
 		DDC677F91EDA76A100A4E19C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DDC677F81EDA76A100A4E19C /* main.m */; };
 		DDC677FD1EDA76A100A4E19C /* TranscriptIndexingService.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = DDC677F21EDA76A100A4E19C /* TranscriptIndexingService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -500,6 +502,8 @@
 		DDB352A31EC90ACA00254815 /* TBProphylaxis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TBProphylaxis.h; sourceTree = "<group>"; };
 		DDB352A41EC90ACA00254815 /* TBProphylaxis.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TBProphylaxis.m; sourceTree = "<group>"; };
 		DDBA0D74208CD5430075670F /* SwiftProtobuf.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = SwiftProtobuf.framework.dSYM; path = Carthage/Build/Mac/SwiftProtobuf.framework.dSYM; sourceTree = "<group>"; };
+		DDBA0D78208D21BD0075670F /* PUINowPlayingInfoCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PUINowPlayingInfoCoordinator.swift; sourceTree = "<group>"; };
+		DDBA0D7A208D3DE70075670F /* PUINowPlayingInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PUINowPlayingInfo.swift; sourceTree = "<group>"; };
 		DDC677EC1EDA6A3000A4E19C /* TranscriptIndexer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptIndexer.swift; sourceTree = "<group>"; };
 		DDC677F21EDA76A100A4E19C /* TranscriptIndexingService.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = TranscriptIndexingService.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDC677F81EDA76A100A4E19C /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -1150,6 +1154,15 @@
 			name = Helpers;
 			sourceTree = "<group>";
 		};
+		DDBA0D77208D21920075670F /* MediaPlayer Support */ = {
+			isa = PBXGroup;
+			children = (
+				DDBA0D78208D21BD0075670F /* PUINowPlayingInfoCoordinator.swift */,
+				DDBA0D7A208D3DE70075670F /* PUINowPlayingInfo.swift */,
+			);
+			path = "MediaPlayer Support";
+			sourceTree = "<group>";
+		};
 		DDC677F31EDA76A100A4E19C /* TranscriptIndexingService */ = {
 			isa = PBXGroup;
 			children = (
@@ -1285,6 +1298,7 @@
 		DDF721971ECA12780054C503 /* PlayerUI */ = {
 			isa = PBXGroup;
 			children = (
+				DDBA0D77208D21920075670F /* MediaPlayer Support */,
 				DDF721A41ECA12A40054C503 /* Controllers */,
 				DDF721A71ECA12A40054C503 /* Definitions */,
 				DDF721AB1ECA12A40054C503 /* Models */,
@@ -2011,11 +2025,13 @@
 				DDF721C91ECA12A40054C503 /* Colors.swift in Sources */,
 				DDED75571ED3C1BF000BA817 /* PUIScrimContainerView.swift in Sources */,
 				DDF721D01ECA12A40054C503 /* PUIPlayerViewDelegates.swift in Sources */,
+				DDBA0D79208D21BD0075670F /* PUINowPlayingInfoCoordinator.swift in Sources */,
 				DDF721CF1ECA12A40054C503 /* PUIExternalPlaybackProvider.swift in Sources */,
 				DDF721DE1ECA12A40054C503 /* PUIPlayerView.swift in Sources */,
 				DDF721D21ECA12A40054C503 /* PUITimelineDelegate.swift in Sources */,
 				DDF721D61ECA12A40054C503 /* DebugLog.swift in Sources */,
 				DDF721D81ECA12A40054C503 /* NSWindow+Snapshot.swift in Sources */,
+				DDBA0D7B208D3DE70075670F /* PUINowPlayingInfo.swift in Sources */,
 				DDC678241EDBA25A00A4E19C /* PUIAnnotationWindow.swift in Sources */,
 				DDF721C71ECA12A40054C503 /* PUIExternalPlaybackStatusViewController.swift in Sources */,
 				DDF721E11ECA12A40054C503 /* PUITimelineView.swift in Sources */,

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		DDDAA4071EC76D9300DF9D02 /* TBPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDAA4061EC76D9300DF9D02 /* TBPreferences.swift */; };
 		DDDAA40A1EC775B500DF9D02 /* TBSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDAA4091EC775B500DF9D02 /* TBSession.swift */; };
 		DDDAA40C1EC798B600DF9D02 /* Preferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDAA40B1EC798B600DF9D02 /* Preferences.swift */; };
+		DDEA82FC20909A4C00D36BE0 /* PUIRemoteCommandCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEA82FB20909A4C00D36BE0 /* PUIRemoteCommandCoordinator.swift */; };
 		DDEA85FB1EB52AB5002AE0EB /* VideoPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEA85F91EB52AB5002AE0EB /* VideoPlayerViewController.swift */; };
 		DDEA85FC1EB52AB5002AE0EB /* VideoPlayerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEA85FA1EB52AB5002AE0EB /* VideoPlayerWindowController.swift */; };
 		DDED75571ED3C1BF000BA817 /* PUIScrimContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDED75561ED3C1BF000BA817 /* PUIScrimContainerView.swift */; };
@@ -538,6 +539,7 @@
 		DDDAA4061EC76D9300DF9D02 /* TBPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBPreferences.swift; sourceTree = "<group>"; };
 		DDDAA4091EC775B500DF9D02 /* TBSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TBSession.swift; sourceTree = "<group>"; };
 		DDDAA40B1EC798B600DF9D02 /* Preferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Preferences.swift; sourceTree = "<group>"; };
+		DDEA82FB20909A4C00D36BE0 /* PUIRemoteCommandCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PUIRemoteCommandCoordinator.swift; sourceTree = "<group>"; };
 		DDEA85F91EB52AB5002AE0EB /* VideoPlayerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoPlayerViewController.swift; sourceTree = "<group>"; };
 		DDEA85FA1EB52AB5002AE0EB /* VideoPlayerWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoPlayerWindowController.swift; sourceTree = "<group>"; };
 		DDED75561ED3C1BF000BA817 /* PUIScrimContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PUIScrimContainerView.swift; sourceTree = "<group>"; };
@@ -1159,6 +1161,7 @@
 			children = (
 				DDBA0D78208D21BD0075670F /* PUINowPlayingInfoCoordinator.swift */,
 				DDBA0D7A208D3DE70075670F /* PUINowPlayingInfo.swift */,
+				DDEA82FB20909A4C00D36BE0 /* PUIRemoteCommandCoordinator.swift */,
 			);
 			path = "MediaPlayer Support";
 			sourceTree = "<group>";
@@ -2041,6 +2044,7 @@
 				DDF721DD1ECA12A40054C503 /* PUIButton.swift in Sources */,
 				DDF721D71ECA12A40054C503 /* NSEvent+ForceTouch.swift in Sources */,
 				DDC6781F1EDB8EDA00A4E19C /* PUIAnnotationWindowController.swift in Sources */,
+				DDEA82FC20909A4C00D36BE0 /* PUIRemoteCommandCoordinator.swift in Sources */,
 				DDF721D91ECA12A40054C503 /* String+CMTime.swift in Sources */,
 				DDF721DC1ECA12A40054C503 /* PUIBufferLayer.swift in Sources */,
 			);

--- a/WWDC/AppCoordinator+Bookmarks.swift
+++ b/WWDC/AppCoordinator+Bookmarks.swift
@@ -31,6 +31,12 @@ extension AppCoordinator: PUITimelineDelegate, VideoPlayerViewControllerDelegate
         // TODO: begin editing new bookmark
     }
 
+    func createFavorite() {
+        guard let session = currentPlayerController?.sessionViewModel.session else { return }
+
+        storage.createFavorite(for: session)
+    }
+
     func viewControllerForTimelineAnnotation(_ annotation: PUITimelineAnnotation) -> NSViewController? {
         guard let bookmark = annotation as? Bookmark else { return nil }
 

--- a/WWDC/AppCoordinator+Shelf.swift
+++ b/WWDC/AppCoordinator+Shelf.swift
@@ -79,6 +79,7 @@ extension AppCoordinator: ShelfViewControllerDelegate {
 
         do {
             let playbackViewModel = try PlaybackViewModel(sessionViewModel: viewModel, storage: storage)
+            playbackViewModel.image = shelfController.shelfView.image
 
             canRestorePlaybackContext = false
             isTransitioningPlayerContext = false

--- a/WWDC/AppCoordinator+Shelf.swift
+++ b/WWDC/AppCoordinator+Shelf.swift
@@ -125,4 +125,8 @@ extension AppCoordinator: ShelfViewControllerDelegate {
         playerController.view.alphaValue = 1
     }
 
+    func publishNowPlayingInfo() {
+        currentPlayerController?.playerView.nowPlayingInfo = currentPlaybackViewModel?.nowPlayingInfo.value
+    }
+
 }

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -138,7 +138,11 @@ final class AppCoordinator {
     var selectedViewModelRegardlessOfTab: SessionViewModel?
 
     /// The viewModel for the current playback session
-    var currentPlaybackViewModel: PlaybackViewModel?
+    var currentPlaybackViewModel: PlaybackViewModel? {
+        didSet {
+            observeNowPlayingInfo()
+        }
+    }
 
     private func setupBindings() {
         tabController.rxActiveTab.subscribe(onNext: { [weak self] activeTab in
@@ -284,6 +288,18 @@ final class AppCoordinator {
     func receiveNotification(with userInfo: [String: Any]) -> Bool {
         return liveObserver.processSubscriptionNotification(with: userInfo) ||
             RemoteEnvironment.shared.processSubscriptionNotification(with: userInfo)
+    }
+
+    // MARK: - Now playing info
+
+    private var nowPlayingInfoBag = DisposeBag()
+
+    private func observeNowPlayingInfo() {
+        nowPlayingInfoBag = DisposeBag()
+
+        currentPlaybackViewModel?.nowPlayingInfo.asObservable().subscribe(onNext: { [weak self] _ in
+            self?.publishNowPlayingInfo()
+        }).disposed(by: nowPlayingInfoBag)
     }
 
     // MARK: - State restoration

--- a/WWDC/PlaybackViewModel.swift
+++ b/WWDC/PlaybackViewModel.swift
@@ -67,6 +67,7 @@ final class PlaybackViewModel {
     var remoteMediaURL: URL?
     var title: String?
     var imageURL: URL?
+    var image: NSImage?
 
     private var timeObserver: Any?
 
@@ -170,7 +171,8 @@ extension PUINowPlayingInfo {
             title: title,
             artist: eventName,
             progress: 0,
-            isLive: playbackViewModel.isLiveStream
+            isLive: playbackViewModel.isLiveStream,
+            image: playbackViewModel.image
         )
     }
 

--- a/WWDC/PlaybackViewModel.swift
+++ b/WWDC/PlaybackViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import ConfCore
 import AVFoundation
 import PlayerUI
+import RxSwift
 
 enum PlaybackError: Error {
     case sessionNotFound(String)
@@ -68,6 +69,8 @@ final class PlaybackViewModel {
     var imageURL: URL?
 
     private var timeObserver: Any?
+
+    var nowPlayingInfo: Variable<PUINowPlayingInfo?> = Variable(nil)
 
     init(sessionViewModel: SessionViewModel, storage: Storage) throws {
         title = sessionViewModel.title
@@ -128,6 +131,7 @@ final class PlaybackViewModel {
         #endif
 
         player = AVPlayer(url: finalUrl)
+        nowPlayingInfo.value = PUINowPlayingInfo(playbackViewModel: self)
 
         if !isLiveStream {
             let p = session.currentPosition()
@@ -141,6 +145,8 @@ final class PlaybackViewModel {
                 let d = Double(CMTimeGetSeconds(duration))
 
                 self?.sessionViewModel.session.setCurrentPosition(p, d)
+
+                if !d.isZero { self?.nowPlayingInfo.value?.progress = p / d }
             }
         }
     }
@@ -150,6 +156,22 @@ final class PlaybackViewModel {
             player.removeTimeObserver(timeObserver)
             self.timeObserver = nil
         }
+    }
+
+}
+
+extension PUINowPlayingInfo {
+
+    init(playbackViewModel: PlaybackViewModel) {
+        let title = playbackViewModel.title ?? "WWDC Session"
+        let eventName = playbackViewModel.sessionViewModel.session.event.first?.name ?? "WWDC"
+
+        self = PUINowPlayingInfo(
+            title: title,
+            artist: eventName,
+            progress: 0,
+            isLive: playbackViewModel.isLiveStream
+        )
     }
 
 }

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -22,6 +22,7 @@ extension Notification.Name {
 protocol VideoPlayerViewControllerDelegate: class {
 
     func createBookmark(at timecode: Double, with snapshot: NSImage?)
+    func createFavorite()
 
 }
 
@@ -284,6 +285,10 @@ extension VideoPlayerViewController: PUIPlayerViewDelegate {
 
     func playerViewWillEnterPictureInPictureMode(_ playerView: PUIPlayerView) {
 
+    }
+
+    func playerViewDidSelectLike(_ playerView: PUIPlayerView) {
+        delegate?.createFavorite()
     }
 
 }


### PR DESCRIPTION
The app will now show up in the "now playing" control center widget and Touch Bar app. The implementation of media remote commands also means it now works reliably with AirPods commands (play/pause, go forward) and will (hopefully) work well with AirPlay 2 devices when that finally comes out.

<img width="330" alt="wwdc now playing widget" src="https://user-images.githubusercontent.com/67184/39249300-bfcb4cea-4874-11e8-830b-5ad82d46c488.png">
<img width="1085" alt="wwdc now playing touch bar" src="https://user-images.githubusercontent.com/67184/39249308-c13667f4-4874-11e8-9b17-c41b24a40e48.png">
