### PR TITLE
Not messing with session identifiers, refactored database migration code

### DIFF
--- a/ConfCore/Event.swift
+++ b/ConfCore/Event.swift
@@ -19,7 +19,13 @@ public class Event: Object {
     @objc public dynamic var name = ""
 
     /// When the event starts
-    @objc public dynamic var startDate = Date.distantPast
+    @objc public dynamic var startDate = Date.distantPast {
+        didSet {
+            year = Calendar.current.component(.year, from: startDate)
+        }
+    }
+
+    @objc public dynamic var year = -1
 
     /// When the event ends
     @objc public dynamic var endDate = Date.distantPast
@@ -37,10 +43,6 @@ public class Event: Object {
 
     public override class func primaryKey() -> String? {
         return "identifier"
-    }
-
-    public var year: Int {
-        return Calendar.current.component(.year, from: startDate)
     }
 
     public static func make(identifier: String, name: String, startDate: Date, endDate: Date, isCurrent: Bool, imagesPath: String) -> Event {

--- a/ConfCore/Event.swift
+++ b/ConfCore/Event.swift
@@ -39,6 +39,10 @@ public class Event: Object {
         return "identifier"
     }
 
+    public var year: Int {
+        return Calendar.current.component(.year, from: startDate)
+    }
+
     public static func make(identifier: String, name: String, startDate: Date, endDate: Date, isCurrent: Bool, imagesPath: String) -> Event {
         let event = Event()
 

--- a/ConfCore/Session.swift
+++ b/ConfCore/Session.swift
@@ -132,17 +132,19 @@ public class Session: Object {
 
         self.assets.append(objectsIn: assets)
 
-        let otherFocuses = other.focuses.map { newFocus -> (Focus) in
-            if newFocus.realm == nil,
-                let existingFocus = realm.object(ofType: Focus.self, forPrimaryKey: newFocus.name) {
-                return existingFocus
-            } else {
-                return newFocus
-            }
-        }
+        other.focuses.forEach { newFocus in
+            let effectiveFocus: Focus
 
-        focuses.removeAll()
-        focuses.append(objectsIn: otherFocuses)
+            if let existingFocus = realm.object(ofType: Focus.self, forPrimaryKey: newFocus.name) {
+                effectiveFocus = existingFocus
+            } else {
+                effectiveFocus = newFocus
+            }
+
+            guard !focuses.contains(where: { $0.name == effectiveFocus.name }) else { return }
+
+            focuses.append(effectiveFocus)
+        }
     }
 
 }

--- a/ConfCore/Session.swift
+++ b/ConfCore/Session.swift
@@ -15,9 +15,6 @@ public class Session: Object {
     /// Unique identifier
     @objc public dynamic var identifier = ""
 
-    /// Session year
-    @objc public dynamic var year = 0
-
     /// Session number
     @objc public dynamic var number = ""
 

--- a/ConfCore/SessionInstancesJSONAdapter.swift
+++ b/ConfCore/SessionInstancesJSONAdapter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyJSON
 
 enum SessionInstanceKeys: String, JSONSubscriptType {
-    case id, keywords, startTime, endTime, type
+    case id, keywords, startTime, endTime, type, eventId
     case favId = "fav_id"
     case room = "roomId"
     case track = "trackId"
@@ -54,6 +54,10 @@ final class SessionInstancesJSONAdapter: Adapter {
             return .error(.missingKey(SessionInstanceKeys.id))
         }
 
+        guard let eventId = input[SessionInstanceKeys.eventId].string else {
+            return .error(.missingKey(SessionInstanceKeys.eventId))
+        }
+
         guard let roomIdentifier = input[SessionInstanceKeys.room].int else {
             return .error(.missingKey(SessionInstanceKeys.room))
         }
@@ -79,7 +83,7 @@ final class SessionInstancesJSONAdapter: Adapter {
         }
 
         instance.identifier = session.identifier
-        instance.eventIdentifier = Event.identifier(from: startDate)
+        instance.eventIdentifier = eventId
         instance.number = id
         instance.session = session
         instance.trackIdentifier = "\(trackIdentifier)"

--- a/ConfCore/SessionInstancesJSONAdapter.swift
+++ b/ConfCore/SessionInstancesJSONAdapter.swift
@@ -30,14 +30,6 @@ final class SessionInstancesJSONAdapter: Adapter {
             return .error(.invalidData)
         }
 
-        var year = Calendar.current.component(.year, from: Date())
-        if Calendar.current.component(.month, from: Date()) < 6 {
-            year -= 1
-        }
-        guard session.year == year else {
-            return .error(.invalidData)
-        }
-
         guard let startGMT = input[SessionInstanceKeys.startTime].string else {
             return .error(.missingKey(SessionInstanceKeys.startTime))
         }

--- a/ConfCore/SessionsJSONAdapter.swift
+++ b/ConfCore/SessionsJSONAdapter.swift
@@ -33,7 +33,7 @@ final class SessionsJSONAdapter: Adapter {
     typealias OutputType = Session
 
     func adapt(_ input: JSON) -> Result<Session, AdapterError> {
-        guard let id = input[SessionKeys.id].string?.replacingOccurrences(of: "wwdc", with: "") else {
+        guard let id = input[SessionKeys.id].string else {
             return .error(.missingKey(SessionKeys.id))
         }
 

--- a/ConfCore/SessionsJSONAdapter.swift
+++ b/ConfCore/SessionsJSONAdapter.swift
@@ -126,7 +126,6 @@ final class SessionsJSONAdapter: Adapter {
 
         session.staticContentId = "\(input[SessionKeys.staticContentId].intValue)"
         session.identifier = id
-        session.year = Int(eventYear) ?? -1
         session.number = "\(eventContentId)"
         session.title = title
         session.summary = summary

--- a/ConfCore/Storage.swift
+++ b/ConfCore/Storage.swift
@@ -196,7 +196,7 @@ public final class Storage {
 
             // add live video assets to sessions
             backgroundRealm.objects(SessionAsset.self).filter("rawAssetType == %@", SessionAssetType.liveStreamVideo.rawValue).forEach { liveAsset in
-                if let session = backgroundRealm.objects(Session.self).filter("year == %d AND number == %@", liveAsset.year, liveAsset.sessionId).first {
+                if let session = backgroundRealm.objects(Session.self).filter("ANY event.year == %d AND number == %@", liveAsset.year, liveAsset.sessionId).first {
                     if !session.assets.contains(liveAsset) {
                         session.assets.append(liveAsset)
                     }
@@ -244,7 +244,7 @@ public final class Storage {
                 } else {
                     backgroundRealm.add(asset, update: true)
 
-                    if let session = backgroundRealm.objects(Session.self).filter("year == %d AND number == %@", asset.year, asset.sessionId).first {
+                    if let session = backgroundRealm.objects(Session.self).filter("ANY event.year == %d AND number == %@", asset.year, asset.sessionId).first {
                         if !session.assets.contains(asset) {
                             session.assets.append(asset)
                         }

--- a/ConfCore/Storage.swift
+++ b/ConfCore/Storage.swift
@@ -106,6 +106,14 @@ public final class Storage {
                 if let existingInstance = backgroundRealm.object(ofType: SessionInstance.self, forPrimaryKey: newInstance.identifier) {
                     existingInstance.merge(with: newInstance, in: backgroundRealm)
                 } else {
+                    // This handles the case where an existing session (which might have user data associated with it) is added to an instance,
+                    // it shouldn't happen in the wild but since we goofed up the year/identifier thing and caused an empty schedule view in 2018,
+                    // we have to make sure we handle this edge case
+                    if let newSession = newInstance.session, let existingSession = backgroundRealm.object(ofType: Session.self, forPrimaryKey: newSession.identifier) {
+                        existingSession.merge(with: newSession, in: backgroundRealm)
+                        newInstance.session = existingSession
+                    }
+
                     backgroundRealm.add(newInstance, update: true)
                 }
             }

--- a/ConfCore/StorageMigrator.swift
+++ b/ConfCore/StorageMigrator.swift
@@ -141,7 +141,7 @@ final class StorageMigrator {
             session?["identifier"] = identifierWithPrefix
 
             guard let transcriptIdentifier = session?["transcriptIdentifier"] as? String, !transcriptIdentifier.isEmpty else {
-                os_log("Session %@{public} had no transcript, skipping", log: log, type: .debug, identifier)
+                os_log("Session %{public}@ had no transcript, skipping", log: log, type: .debug, identifier)
                 return
             }
 

--- a/ConfCore/StorageMigrator.swift
+++ b/ConfCore/StorageMigrator.swift
@@ -1,0 +1,161 @@
+//
+//  StorageMigrator.swift
+//  ConfCore
+//
+//  Created by Guilherme Rambo on 29/04/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Foundation
+import RealmSwift
+import os.log
+
+final class StorageMigrator {
+
+    let migration: Migration
+    let oldVersion: UInt64
+    let log = OSLog(subsystem: "ConfCore", category: "StorageMigrator")
+
+    private typealias SchemaVersion = UInt64
+    private typealias MigrationBlock = (Migration, SchemaVersion, OSLog) -> Void
+
+    /// Migration block in `prescription.key` will be executed if the previous version is `< prescription.key`
+    private let prescription: [SchemaVersion: MigrationBlock] = [
+        10: migrateAlphaCleanup,
+        15: migrateDownloadModelRemoval,
+        31: migrateContentThumbnails,
+        32: migrateSessionModels,
+        34: migrateOldTranscriptModels,
+        37: migrateIdentifiersWithoutReplacement
+    ]
+
+    init(migration: Migration, oldVersion: UInt64) {
+        self.migration = migration
+        self.oldVersion = oldVersion
+    }
+
+    private(set) var isPerforming = false
+
+    func perform() {
+        guard !isPerforming else {
+            os_log("perform() called while isPerform = true", log: log, type: .error)
+            return
+        }
+
+        isPerforming = true
+        defer { isPerforming = false }
+
+        let migrationsToPerform = prescription.filter { oldVersion < $0.key }
+
+        guard migrationsToPerform.count > 0 else {
+            os_log("No migrations to perform", log: log, type: .info)
+            return
+        }
+
+        let versions = migrationsToPerform.map { $0.key }
+        os_log("Will perform migrations for the following schema versions: %{public}@",
+               log: log,
+               type: .info,
+               String(describing: versions))
+
+        migrationsToPerform.forEach { $0.value(migration, oldVersion, log) }
+    }
+
+    private static func migrateAlphaCleanup(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("migrateAlphaCleanup", log: log, type: .info)
+
+        migration.deleteData(forType: "Event")
+        migration.deleteData(forType: "Track")
+        migration.deleteData(forType: "Room")
+        migration.deleteData(forType: "Favorite")
+        migration.deleteData(forType: "SessionProgress")
+        migration.deleteData(forType: "Session")
+        migration.deleteData(forType: "SessionInstance")
+        migration.deleteData(forType: "SessionAsset")
+        migration.deleteData(forType: "SessionAsset")
+    }
+
+    private static func migrateDownloadModelRemoval(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("migrateDownloadModelRemoval", log: log, type: .info)
+
+        migration.deleteData(forType: "Download")
+    }
+
+    private static func migrateContentThumbnails(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("migrateContentThumbnails", log: log, type: .info)
+
+        // remove cached images which might have generic session thumbs instead of the correct ones
+        migration.deleteData(forType: "ImageCacheEntity")
+
+        // delete live stream assets (some of them got duplicated during the week)
+        migration.enumerateObjects(ofType: "SessionAsset") { asset, _ in
+            guard let asset = asset else { return }
+
+            if asset["rawAssetType"] as? String == SessionAssetType.liveStreamVideo.rawValue {
+                migration.delete(asset)
+            }
+        }
+    }
+
+    private static func migrateSessionModels(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("migrateSessionModels", log: log, type: .info)
+
+        migration.deleteData(forType: "Event")
+        migration.deleteData(forType: "Track")
+        migration.deleteData(forType: "ScheduleSection")
+    }
+
+    private static func migrateOldTranscriptModels(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("migrateOldTranscriptModels", log: log, type: .info)
+
+        migration.deleteData(forType: "Transcript")
+        migration.deleteData(forType: "TranscriptAnnotation")
+
+        migration.enumerateObjects(ofType: "Session") { _, session in
+            session?["transcriptIdentifier"] = ""
+        }
+    }
+
+    private static func migrateIdentifiersWithoutReplacement(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        // version 37 changed identifiers to include the event name prefix (i.e. "wwdc" or "fall")
+
+        // add `year` to `Event` based on the event's start date
+        migration.enumerateObjects(ofType: "Event") { _, event in
+            guard let startDate = event?["startDate"] as? Date else {
+                fatalError("Corrupt database during migration: Event.startDate must be a Date")
+            }
+
+            event?["year"] = Calendar.current.component(.year, from: startDate)
+        }
+
+        // add `wwdc` to `Session.identifier` unless it is a "fall" session
+        migration.enumerateObjects(ofType: "Session") { _, session in
+            guard let identifier = session?["identifier"] as? String else {
+                fatalError("Corrupt database during migration: Session.identifier must be a String")
+            }
+
+            guard !identifier.contains("fall") else { return }
+
+            let identifierWithPrefix = "wwdc" + identifier
+
+            session?["identifier"] = identifierWithPrefix
+
+            guard let transcriptIdentifier = session?["transcriptIdentifier"] as? String, !transcriptIdentifier.isEmpty else {
+                os_log("Session %@{public} had no transcript, skipping", log: log, type: .debug, identifier)
+                return
+            }
+
+            session?["transcriptIdentifier"] = identifierWithPrefix
+        }
+
+        // add `wwdc` to `Transcript.identifier`
+        migration.enumerateObjects(ofType: "Transcript") { _, transcript in
+            guard let identifier = transcript?["identifier"] as? String else {
+                fatalError("Corrupt database during migration: Transcript.identifier must be a String")
+            }
+
+            transcript?["identifier"] = "wwdc" + identifier
+        }
+    }
+
+}

--- a/ConfCore/TranscriptIndexer.swift
+++ b/ConfCore/TranscriptIndexer.swift
@@ -41,7 +41,7 @@ public final class TranscriptIndexer {
 
     public static let minTranscriptableSessionLimit: Int = 20
     // TODO: increase 2017 to 2018 when transcripts for 2017 become available
-    public static let transcriptableSessionsPredicate: NSPredicate = NSPredicate(format: "year > 2012 AND year < 2017 AND transcriptIdentifier == '' AND SUBQUERY(assets, $asset, $asset.rawAssetType == %@).@count > 0", SessionAssetType.streamingVideo.rawValue)
+    public static let transcriptableSessionsPredicate: NSPredicate = NSPredicate(format: "ANY event.year > 2012 AND ANY event.year < 2017 AND transcriptIdentifier == '' AND SUBQUERY(assets, $asset, $asset.rawAssetType == %@).@count > 0", SessionAssetType.streamingVideo.rawValue)
 
     public static func needsUpdate(in storage: Storage) -> Bool {
         let transcriptedSessions = storage.realm.objects(Session.self).filter(TranscriptIndexer.transcriptableSessionsPredicate)

--- a/ConfCore/TranscriptIndexer.swift
+++ b/ConfCore/TranscriptIndexer.swift
@@ -69,10 +69,11 @@ public final class TranscriptIndexer {
 
         for key in sessionKeys {
             guard let session = storage.realm.object(ofType: Session.self, forPrimaryKey: key) else { return }
+            guard let event = session.event.first else { return }
 
             guard session.transcriptIdentifier.isEmpty else { continue }
 
-            indexTranscript(for: session.number, in: session.year, primaryKey: key)
+            indexTranscript(for: session.number, in: event.year, primaryKey: key)
         }
     }
 

--- a/ConfCore/TranscriptsJSONAdapter.swift
+++ b/ConfCore/TranscriptsJSONAdapter.swift
@@ -54,7 +54,7 @@ final class TranscriptsJSONAdapter: Adapter {
 
         let transcript = Transcript()
 
-        transcript.identifier = "\(year)-\(number)"
+        transcript.identifier = "wwdc\(year)-\(number)"
         transcript.fullText = input[TranscriptKeys.fullText].string ?? ""
         transcript.annotations.append(objectsIn: annotations)
 

--- a/ConfCoreTests/AdapterTests.swift
+++ b/ConfCoreTests/AdapterTests.swift
@@ -296,7 +296,7 @@ class AdapterTests: XCTestCase {
             XCTAssertEqual(instances[0].session?.focuses[0].name, "iOS")
             XCTAssertEqual(instances[0].session?.focuses[1].name, "macOS")
             XCTAssertEqual(instances[0].session?.focuses[2].name, "tvOS")
-            XCTAssertEqual(instances[0].identifier, "2017-8080")
+            XCTAssertEqual(instances[0].identifier, "wwdc2017-8080")
             XCTAssertEqual(instances[0].number, "wwdc2017-8080")
             XCTAssertEqual(instances[0].sessionType, 1)
             XCTAssertEqual(instances[0].keywords.count, 0)
@@ -313,7 +313,7 @@ class AdapterTests: XCTestCase {
             XCTAssertEqual(instances[2].session?.focuses[0].name, "iOS")
             XCTAssertEqual(instances[2].session?.focuses[1].name, "macOS")
             XCTAssertEqual(instances[2].session?.focuses[2].name, "tvOS")
-            XCTAssertEqual(instances[2].identifier, "2017-4170")
+            XCTAssertEqual(instances[2].identifier, "wwdc2017-4170")
             XCTAssertEqual(instances[2].number, "wwdc2017-4170")
             XCTAssertEqual(instances[2].sessionType, 1)
             XCTAssertEqual(instances[2].keywords.count, 0)
@@ -364,7 +364,7 @@ class AdapterTests: XCTestCase {
         case .error(let error):
             XCTFail(error.localizedDescription)
         case .success(let transcript):
-            XCTAssertEqual(transcript.identifier, "2014-101")
+            XCTAssertEqual(transcript.identifier, "wwdc2014-101")
             XCTAssertEqual(transcript.fullText.count, 92023)
             XCTAssertEqual(transcript.annotations.count, 2219)
             XCTAssertEqual(transcript.annotations.first!.timecode, 0.506)

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		DD9301BC1EE3205800BE724B /* ChromeCastCore.framework.dSYM in Carthage: Copy DSYMs */ = {isa = PBXBuildFile; fileRef = DD9301BA1EE3205800BE724B /* ChromeCastCore.framework.dSYM */; };
 		DD9301C01EE3212D00BE724B /* ChromeCastPlaybackProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9301BF1EE3212D00BE724B /* ChromeCastPlaybackProvider.swift */; };
 		DD9564231ED27FBE00051D07 /* NSImage+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9564221ED27FBE00051D07 /* NSImage+Thumbnail.swift */; };
+		DD9AEFBB20963D3C00EA203F /* StorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */; };
 		DDA5E4941EDCD6E7003B1780 /* WhiteSpinner.car in Resources */ = {isa = PBXBuildFile; fileRef = DDA5E4931EDCD6E7003B1780 /* WhiteSpinner.car */; };
 		DDAE001B1EC52D2B0036C7E9 /* SessionProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE001A1EC52D2B0036C7E9 /* SessionProgress.swift */; };
 		DDAE001D1EC534BF0036C7E9 /* TrackColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE001C1EC534BF0036C7E9 /* TrackColorView.swift */; };
@@ -473,6 +474,7 @@
 		DD9301BA1EE3205800BE724B /* ChromeCastCore.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = ChromeCastCore.framework.dSYM; path = Carthage/Build/Mac/ChromeCastCore.framework.dSYM; sourceTree = "<group>"; };
 		DD9301BF1EE3212D00BE724B /* ChromeCastPlaybackProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChromeCastPlaybackProvider.swift; sourceTree = "<group>"; };
 		DD9564221ED27FBE00051D07 /* NSImage+Thumbnail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+Thumbnail.swift"; sourceTree = "<group>"; };
+		DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMigrator.swift; sourceTree = "<group>"; };
 		DDA5E4931EDCD6E7003B1780 /* WhiteSpinner.car */ = {isa = PBXFileReference; lastKnownFileType = file; name = WhiteSpinner.car; path = Design/WhiteSpinner.car; sourceTree = SOURCE_ROOT; };
 		DDAE001A1EC52D2B0036C7E9 /* SessionProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionProgress.swift; sourceTree = "<group>"; };
 		DDAE001C1EC534BF0036C7E9 /* TrackColorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackColorView.swift; sourceTree = "<group>"; };
@@ -706,6 +708,7 @@
 			isa = PBXGroup;
 			children = (
 				DD0F0C551E7B8DD600B52184 /* Storage.swift */,
+				DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */,
 				DDC677EC1EDA6A3000A4E19C /* TranscriptIndexer.swift */,
 			);
 			name = Storage;
@@ -1964,6 +1967,7 @@
 				DD0353491E5545B300D5E343 /* SessionInstancesJSONAdapter.swift in Sources */,
 				DD65FD631E48ACA90054DD35 /* Keyword.swift in Sources */,
 				DD54CD101E4AB8ED000BF5F2 /* KeywordsJSONAdapter.swift in Sources */,
+				DD9AEFBB20963D3C00EA203F /* StorageMigrator.swift in Sources */,
 				DD65FD551E48A0A70054DD35 /* Room.swift in Sources */,
 				DD65FD691E48BBEF0054DD35 /* TranscriptAnnotation.swift in Sources */,
 				DDAE7C4D1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift in Sources */,

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
@@ -78,7 +78,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WWDCUseDebugStorage YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-transcripts"

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
@@ -78,7 +78,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WWDCUseDebugStorage YES"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-transcripts"

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Constants {
 
-    static let coreSchemaVersion: UInt64 = 36
+    static let coreSchemaVersion: UInt64 = 37
 
     static let thumbnailHeight: CGFloat = 150
 


### PR DESCRIPTION
As pointed out in #331 by @bcmn, the app was replacing `"wwdc"` in session identifiers for some unknown reason and this could cause issues with different events (like the `"fall"` event).

With this PR, I removed that unnecessary replacement, we're now using the identifiers as they come from the API. I also moved the `year` property from `Session` to `Event` as a stored property so it can be queried and changed the code where applicable to use the new property.

Migration code has been refactored and a new migration was added to address this change in identifiers. A change had to be made to the `store` method in order to keep user data from being lost with the migration.

I have done extensive manual testing to make sure nothing broke, but we should probably be thinking about writing automated tests for migrations as outlined in #329. 