### PR TITLE
Implemented UI for related sessions

### DIFF
--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		DD9564231ED27FBE00051D07 /* NSImage+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9564221ED27FBE00051D07 /* NSImage+Thumbnail.swift */; };
 		DD9AEFBB20963D3C00EA203F /* StorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */; };
 		DDA5E4941EDCD6E7003B1780 /* WhiteSpinner.car in Resources */ = {isa = PBXBuildFile; fileRef = DDA5E4931EDCD6E7003B1780 /* WhiteSpinner.car */; };
+		DDA60E1320A90655002EECF5 /* SessionCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA60E1220A90655002EECF5 /* SessionCellView.swift */; };
 		DDAE001B1EC52D2B0036C7E9 /* SessionProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE001A1EC52D2B0036C7E9 /* SessionProgress.swift */; };
 		DDAE001D1EC534BF0036C7E9 /* TrackColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE001C1EC534BF0036C7E9 /* TrackColorView.swift */; };
 		DDAE7C4D1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE7C4C1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift */; };
@@ -479,6 +480,7 @@
 		DD9564221ED27FBE00051D07 /* NSImage+Thumbnail.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+Thumbnail.swift"; sourceTree = "<group>"; };
 		DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMigrator.swift; sourceTree = "<group>"; };
 		DDA5E4931EDCD6E7003B1780 /* WhiteSpinner.car */ = {isa = PBXFileReference; lastKnownFileType = file; name = WhiteSpinner.car; path = Design/WhiteSpinner.car; sourceTree = SOURCE_ROOT; };
+		DDA60E1220A90655002EECF5 /* SessionCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCellView.swift; sourceTree = "<group>"; };
 		DDAE001A1EC52D2B0036C7E9 /* SessionProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionProgress.swift; sourceTree = "<group>"; };
 		DDAE001C1EC534BF0036C7E9 /* TrackColorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackColorView.swift; sourceTree = "<group>"; };
 		DDAE7C4C1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptsJSONAdapter.swift; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 				DDC678181EDB2CD300A4E19C /* ActionLabel.swift */,
 				DD6E06F31EDBC11F000EAEA4 /* WWDCTextButton.swift */,
 				DD6E06F51EDBC379000EAEA4 /* WWDCBottomBorderView.swift */,
+				DDA60E1220A90655002EECF5 /* SessionCellView.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1915,6 +1918,7 @@
 				DD0159A91ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift in Sources */,
 				DD6E06F41EDBC11F000EAEA4 /* WWDCTextButton.swift in Sources */,
 				DD7F38621EABD6CF002D8C00 /* SessionsTableViewController.swift in Sources */,
+				DDA60E1320A90655002EECF5 /* SessionCellView.swift in Sources */,
 				DDF32EAD1EBE2F9F0028E39D /* SessionRow.swift in Sources */,
 				DD6E06F81EDBC62D000EAEA4 /* TranscriptTableViewController.swift in Sources */,
 				DD36A4B01E478C6A00B2EA88 /* AppDelegate.swift in Sources */,

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		DD4648451ECA53A4005C57C6 /* CMSSubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4648441ECA53A4005C57C6 /* CMSSubscriptionManager.swift */; };
 		DD4648471ECA5947005C57C6 /* WWDCWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4648461ECA5947005C57C6 /* WWDCWindow.swift */; };
 		DD4648491ECA5EC0005C57C6 /* NSToolbarItemViewer+Overrides.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4648481ECA5EC0005C57C6 /* NSToolbarItemViewer+Overrides.m */; };
+		DD4873D320AE5FF3005033CE /* AppCoordinator+RelatedSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4873D220AE5FF3005033CE /* AppCoordinator+RelatedSessions.swift */; };
 		DD4DED611ED6577100624EAF /* Sparkle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD4DED601ED6577100624EAF /* Sparkle.framework */; };
 		DD4DED641ED6579900624EAF /* Sparkle.framework.dSYM in Carthage: Copy DSYMs */ = {isa = PBXBuildFile; fileRef = DD4DED631ED6579900624EAF /* Sparkle.framework.dSYM */; };
 		DD4DED681ED6604300624EAF /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD4DED661ED6604300624EAF /* Fabric.framework */; };
@@ -407,6 +408,7 @@
 		DD4648441ECA53A4005C57C6 /* CMSSubscriptionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CMSSubscriptionManager.swift; sourceTree = "<group>"; };
 		DD4648461ECA5947005C57C6 /* WWDCWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WWDCWindow.swift; sourceTree = "<group>"; };
 		DD4648481ECA5EC0005C57C6 /* NSToolbarItemViewer+Overrides.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSToolbarItemViewer+Overrides.m"; sourceTree = "<group>"; };
+		DD4873D220AE5FF3005033CE /* AppCoordinator+RelatedSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+RelatedSessions.swift"; sourceTree = "<group>"; };
 		DD4DED601ED6577100624EAF /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = Carthage/Build/Mac/Sparkle.framework; sourceTree = "<group>"; };
 		DD4DED631ED6579900624EAF /* Sparkle.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = Sparkle.framework.dSYM; path = Carthage/Build/Mac/Sparkle.framework.dSYM; sourceTree = "<group>"; };
 		DD4DED661ED6604300624EAF /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
@@ -796,6 +798,7 @@
 				DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */,
 				DDF32EB61EBE65930028E39D /* AppCoordinator+UserActivity.swift */,
 				DDF32EBA1EBE65DD0028E39D /* AppCoordinator+SessionActions.swift */,
+				DD4873D220AE5FF3005033CE /* AppCoordinator+RelatedSessions.swift */,
 				DDFA10BE1EBEAAAD001DCF66 /* DownloadManager.swift */,
 				DD0159FB1ED23F7700F980F1 /* RemoteEnvironment.swift */,
 				DDB3529D1EC8D8CD00254815 /* main.m */,
@@ -1952,6 +1955,7 @@
 				DD2E27881EAC2CCB0009D7B6 /* ShelfView.swift in Sources */,
 				DDEDFCF51ED9FF8A002477C8 /* WWDCSegmentedControl.swift in Sources */,
 				DDF32EB71EBE65930028E39D /* AppCoordinator+UserActivity.swift in Sources */,
+				DD4873D320AE5FF3005033CE /* AppCoordinator+RelatedSessions.swift in Sources */,
 				DD382B7C1EAC345F009760C4 /* NSImage+CGImage.m in Sources */,
 				DDEDFCEF1ED92785002477C8 /* MultipleChoiceFilter.swift in Sources */,
 				DDEA85FB1EB52AB5002AE0EB /* VideoPlayerViewController.swift in Sources */,

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		DD9AEFBB20963D3C00EA203F /* StorageMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */; };
 		DDA5E4941EDCD6E7003B1780 /* WhiteSpinner.car in Resources */ = {isa = PBXBuildFile; fileRef = DDA5E4931EDCD6E7003B1780 /* WhiteSpinner.car */; };
 		DDA60E1320A90655002EECF5 /* SessionCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA60E1220A90655002EECF5 /* SessionCellView.swift */; };
+		DDA60E1520A907B6002EECF5 /* SessionCollectionViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA60E1420A907B6002EECF5 /* SessionCollectionViewItem.swift */; };
+		DDA60E1720A9083E002EECF5 /* RelatedSessionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA60E1620A9083E002EECF5 /* RelatedSessionsViewController.swift */; };
 		DDAE001B1EC52D2B0036C7E9 /* SessionProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE001A1EC52D2B0036C7E9 /* SessionProgress.swift */; };
 		DDAE001D1EC534BF0036C7E9 /* TrackColorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE001C1EC534BF0036C7E9 /* TrackColorView.swift */; };
 		DDAE7C4D1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAE7C4C1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift */; };
@@ -481,6 +483,8 @@
 		DD9AEFBA20963D3C00EA203F /* StorageMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageMigrator.swift; sourceTree = "<group>"; };
 		DDA5E4931EDCD6E7003B1780 /* WhiteSpinner.car */ = {isa = PBXFileReference; lastKnownFileType = file; name = WhiteSpinner.car; path = Design/WhiteSpinner.car; sourceTree = SOURCE_ROOT; };
 		DDA60E1220A90655002EECF5 /* SessionCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCellView.swift; sourceTree = "<group>"; };
+		DDA60E1420A907B6002EECF5 /* SessionCollectionViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCollectionViewItem.swift; sourceTree = "<group>"; };
+		DDA60E1620A9083E002EECF5 /* RelatedSessionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedSessionsViewController.swift; sourceTree = "<group>"; };
 		DDAE001A1EC52D2B0036C7E9 /* SessionProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionProgress.swift; sourceTree = "<group>"; };
 		DDAE001C1EC534BF0036C7E9 /* TrackColorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackColorView.swift; sourceTree = "<group>"; };
 		DDAE7C4C1E5BA4D100CEA205 /* TranscriptsJSONAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TranscriptsJSONAdapter.swift; sourceTree = "<group>"; };
@@ -834,6 +838,7 @@
 				DD6E06F31EDBC11F000EAEA4 /* WWDCTextButton.swift */,
 				DD6E06F51EDBC379000EAEA4 /* WWDCBottomBorderView.swift */,
 				DDA60E1220A90655002EECF5 /* SessionCellView.swift */,
+				DDA60E1420A907B6002EECF5 /* SessionCollectionViewItem.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -1025,6 +1030,7 @@
 			isa = PBXGroup;
 			children = (
 				DD7F38791EAC0CE3002D8C00 /* SessionSummaryViewController.swift */,
+				DDA60E1620A9083E002EECF5 /* RelatedSessionsViewController.swift */,
 				DDF32EB21EBE5C4D0028E39D /* SessionActionsViewController.swift */,
 			);
 			name = Summary;
@@ -1903,6 +1909,8 @@
 				DDFA10BF1EBEAAAD001DCF66 /* DownloadManager.swift in Sources */,
 				DDD930711ED4EF1F00D61BE3 /* Fonts.swift in Sources */,
 				DD0159A71ECFE26200F980F1 /* DeepLink.swift in Sources */,
+				DDA60E1720A9083E002EECF5 /* RelatedSessionsViewController.swift in Sources */,
+				DDA60E1520A907B6002EECF5 /* SessionCollectionViewItem.swift in Sources */,
 				DD7F38881EAC2275002D8C00 /* PathUtil.swift in Sources */,
 				DDB352821EC7C55300254815 /* DateProvider.swift in Sources */,
 				DDC678221EDB956700A4E19C /* BookmarkViewController.swift in Sources */,

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
@@ -109,7 +109,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "2017-06-06T09:20:00-07:00"
+            argument = "2017-06-05T15:00:00-03:00"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/WWDC/AppCoordinator+RelatedSessions.swift
+++ b/WWDC/AppCoordinator+RelatedSessions.swift
@@ -1,0 +1,17 @@
+//
+//  AppCoordinator+RelatedSessions.swift
+//  WWDC
+//
+//  Created by Guilherme Rambo on 17/05/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Cocoa
+
+extension AppCoordinator: RelatedSessionsViewControllerDelegate {
+
+    func relatedSessionsViewController(_ controller: RelatedSessionsViewController, didSelectSession session: SessionViewModel) {
+        currentListController.selectSession(with: session.identifier)
+    }
+
+}

--- a/WWDC/AppCoordinator+RelatedSessions.swift
+++ b/WWDC/AppCoordinator+RelatedSessions.swift
@@ -10,8 +10,18 @@ import Cocoa
 
 extension AppCoordinator: RelatedSessionsViewControllerDelegate {
 
-    func relatedSessionsViewController(_ controller: RelatedSessionsViewController, didSelectSession session: SessionViewModel) {
-        currentListController.selectSession(with: session.identifier)
+    func selectSessionOnAppropriateTab(with viewModel: SessionViewModel) {
+        if ![.video, .session].contains(viewModel.sessionInstance.type) {
+            // If the related session selected is not a video or regular session, we must be
+            // on the schedule tab to show it, since the videos tab only shows videos
+            tabController.activeTab = .schedule
+        }
+
+        currentListController.selectSession(with: viewModel.identifier)
+    }
+
+    func relatedSessionsViewController(_ controller: RelatedSessionsViewController, didSelectSession viewModel: SessionViewModel) {
+        selectSessionOnAppropriateTab(with: viewModel)
     }
 
 }

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -184,11 +184,13 @@ final class AppCoordinator {
 
         videoDetail.shelfController.delegate = self
         videoDetail.summaryController.actionsViewController.delegate = self
+        videoDetail.summaryController.relatedSessionsViewController.delegate = self
 
         let scheduleDetail = scheduleController.detailViewController
 
         scheduleDetail.shelfController.delegate = self
         scheduleDetail.summaryController.actionsViewController.delegate = self
+        scheduleDetail.summaryController.relatedSessionsViewController.delegate = self
 
         videosController.listViewController.delegate = self
         scheduleController.listViewController.delegate = self

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -40,6 +40,7 @@ final class RelatedSessionsViewController: NSViewController {
     var sessions: [SessionViewModel] = [] {
         didSet {
             collectionView.reloadData()
+            view.isHidden = sessions.count == 0
         }
     }
 

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -113,6 +113,8 @@ final class RelatedSessionsViewController: NSViewController {
     }
 
     override func scrollToBeginningOfDocument(_ sender: Any?) {
+        guard !sessions.isEmpty else { return }
+
         let beginningSet = Set([IndexPath(item: 0, section: 0)])
         collectionView.scrollToItems(at: beginningSet, scrollPosition: .leadingEdge)
     }

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -68,7 +68,7 @@ final class RelatedSessionsViewController: NSViewController {
         let v = NSScrollView(frame: view.bounds)
 
         v.hasHorizontalScroller = true
-        v.hasVerticalScroller = false
+        v.horizontalScroller?.alphaValue = 0
 
         return v
     }()
@@ -110,6 +110,11 @@ final class RelatedSessionsViewController: NSViewController {
         super.viewDidLoad()
 
         collectionView.register(SessionCollectionViewItem.self, forItemWithIdentifier: .sessionItem)
+    }
+
+    override func scrollToBeginningOfDocument(_ sender: Any?) {
+        let beginningSet = Set([IndexPath(item: 0, section: 0)])
+        collectionView.scrollToItems(at: beginningSet, scrollPosition: .leadingEdge)
     }
 
 }

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -15,7 +15,7 @@ private extension NSUserInterfaceItemIdentifier {
 }
 
 protocol RelatedSessionsViewControllerDelegate: class {
-    func relatedSessionsViewController(_ controller: RelatedSessionsViewController, didSelectSession session: SessionViewModel)
+    func relatedSessionsViewController(_ controller: RelatedSessionsViewController, didSelectSession viewModel: SessionViewModel)
 }
 
 final class RelatedSessionsViewController: NSViewController {

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -1,0 +1,137 @@
+//
+//  RelatedSessionsViewController.swift
+//  WWDC
+//
+//  Created by Guilherme Rambo on 13/05/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Cocoa
+import RxSwift
+import RxCocoa
+
+private extension NSUserInterfaceItemIdentifier {
+    static let sessionItem = NSUserInterfaceItemIdentifier("sessionCell")
+}
+
+protocol RelatedSessionsViewControllerDelegate: class {
+    func relatedSessionsViewController(_ controller: RelatedSessionsViewController, didSelectSession session: SessionViewModel)
+}
+
+final class RelatedSessionsViewController: NSViewController {
+
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    struct Metrics {
+        static let height: CGFloat = 96
+        static let itemHeight: CGFloat = 64
+        static let itemWidth: CGFloat = 360
+        static let padding: CGFloat = 24
+    }
+
+    private let disposeBag = DisposeBag()
+
+    var sessions: [SessionViewModel] = [] {
+        didSet {
+            collectionView.reloadData()
+        }
+    }
+
+    weak var delegate: RelatedSessionsViewControllerDelegate?
+
+    private lazy var titleLabel: WWDCTextField = {
+        let l = WWDCTextField(labelWithString: "Related Videos")
+        l.cell?.backgroundStyle = .dark
+        l.lineBreakMode = .byTruncatingTail
+        l.maximumNumberOfLines = 1
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.textColor = .secondaryText
+        l.font = .systemFont(ofSize: 20, weight: .semibold)
+
+        return l
+    }()
+
+    private lazy var scrollView: NSScrollView = {
+        let v = NSScrollView(frame: view.bounds)
+
+        v.hasHorizontalScroller = true
+        v.hasVerticalScroller = false
+
+        return v
+    }()
+
+    private lazy var collectionView: NSCollectionView = {
+        var rect = view.bounds
+        rect.size.height = Metrics.itemHeight
+
+        let v = NSCollectionView(frame: rect)
+
+        let layout = NSCollectionViewFlowLayout()
+        layout.itemSize = NSSize(width: Metrics.itemWidth, height: Metrics.itemHeight)
+        layout.scrollDirection = .horizontal
+        layout.minimumInteritemSpacing = Metrics.padding
+
+        v.collectionViewLayout = layout
+        v.dataSource = self
+        v.delegate = self
+        v.autoresizingMask = [.width, .minYMargin]
+
+        return v
+    }()
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 600, height: Metrics.height))
+        view.wantsLayer = true
+
+        scrollView.frame = NSRect(x: 0, y: 0, width: view.bounds.width, height: Metrics.itemHeight)
+        scrollView.autoresizingMask = [.width, .minYMargin]
+        view.addSubview(scrollView)
+        scrollView.documentView = collectionView
+
+        view.addSubview(titleLabel)
+        titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        titleLabel.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        collectionView.register(SessionCollectionViewItem.self, forItemWithIdentifier: .sessionItem)
+    }
+
+}
+
+extension RelatedSessionsViewController: NSCollectionViewDelegate, NSCollectionViewDataSource {
+
+    func numberOfSections(in collectionView: NSCollectionView) -> Int {
+        return 1
+    }
+
+    func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
+        return sessions.count
+    }
+
+    func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
+        guard let item = collectionView.makeItem(withIdentifier: .sessionItem, for: indexPath) as? SessionCollectionViewItem else {
+            return NSCollectionViewItem()
+        }
+
+        item.viewModel = sessions[indexPath.item]
+        item.doubleClicked = { [unowned self] viewModel in
+            self.delegate?.relatedSessionsViewController(self, didSelectSession: viewModel)
+        }
+
+        return item
+    }
+
+    func collectionView(_ collectionView: NSCollectionView, shouldChangeItemsAt indexPaths: Set<IndexPath>, to highlightState: NSCollectionViewItem.HighlightState) -> Set<IndexPath> {
+        return Set<IndexPath>()
+    }
+
+}

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -68,7 +68,7 @@ final class RelatedSessionsViewController: NSViewController {
         let v = NSScrollView(frame: view.bounds)
 
         v.hasHorizontalScroller = true
-        v.horizontalScroller?.alphaValue = 0
+//        v.horizontalScroller?.alphaValue = 0
 
         return v
     }()
@@ -137,7 +137,7 @@ extension RelatedSessionsViewController: NSCollectionViewDelegate, NSCollectionV
         }
 
         item.viewModel = sessions[indexPath.item]
-        item.doubleClicked = { [unowned self] viewModel in
+        item.onClicked = { [unowned self] viewModel in
             self.delegate?.relatedSessionsViewController(self, didSelectSession: viewModel)
         }
 

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -68,7 +68,7 @@ final class RelatedSessionsViewController: NSViewController {
         let v = NSScrollView(frame: view.bounds)
 
         v.hasHorizontalScroller = true
-//        v.horizontalScroller?.alphaValue = 0
+        v.horizontalScroller?.alphaValue = 0
 
         return v
     }()

--- a/WWDC/RelatedSessionsViewController.swift
+++ b/WWDC/RelatedSessionsViewController.swift
@@ -46,8 +46,14 @@ final class RelatedSessionsViewController: NSViewController {
 
     weak var delegate: RelatedSessionsViewControllerDelegate?
 
+    override var title: String? {
+        didSet {
+            titleLabel.stringValue = title ?? ""
+        }
+    }
+
     private lazy var titleLabel: WWDCTextField = {
-        let l = WWDCTextField(labelWithString: "Related Videos")
+        let l = WWDCTextField(labelWithString: "")
         l.cell?.backgroundStyle = .dark
         l.lineBreakMode = .byTruncatingTail
         l.maximumNumberOfLines = 1

--- a/WWDC/SessionCellView.swift
+++ b/WWDC/SessionCellView.swift
@@ -251,5 +251,5 @@ final class SessionCellView: NSView {
         downloadedImageView.isHidden = true
         favoritedImageView.isHidden = true
     }
-    
+
 }

--- a/WWDC/SessionCellView.swift
+++ b/WWDC/SessionCellView.swift
@@ -1,0 +1,255 @@
+//
+//  SessionCellView.swift
+//  WWDC
+//
+//  Created by Guilherme Rambo on 13/05/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Cocoa
+import RxSwift
+import RxCocoa
+
+final class SessionCellView: NSView {
+
+    private var disposeBag = DisposeBag()
+
+    var viewModel: SessionViewModel? {
+        didSet {
+            guard viewModel !== oldValue else { return }
+
+            thumbnailImageView.image = #imageLiteral(resourceName: "noimage")
+            bindUI()
+        }
+    }
+
+    private weak var imageDownloadOperation: Operation?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        buildUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        imageDownloadOperation?.cancel()
+
+        downloadedImageView.isHidden = true
+        favoritedImageView.isHidden = true
+    }
+
+    private func bindUI() {
+        disposeBag = DisposeBag()
+
+        guard let viewModel = viewModel else { return }
+
+        viewModel.rxTitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(titleLabel.rx.text).disposed(by: disposeBag)
+        viewModel.rxSubtitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(subtitleLabel.rx.text).disposed(by: disposeBag)
+        viewModel.rxContext.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(contextLabel.rx.text).disposed(by: disposeBag)
+
+        viewModel.rxIsFavorite.distinctUntilChanged().map({ !$0 }).bind(to: favoritedImageView.rx.isHidden).disposed(by: disposeBag)
+        viewModel.rxIsDownloaded.distinctUntilChanged().map({ !$0 }).bind(to: downloadedImageView.rx.isHidden).disposed(by: disposeBag)
+
+        let isSnowFlake = Observable.zip(viewModel.rxIsCurrentlyLive, viewModel.rxIsLab)
+
+        isSnowFlake.map({ !$0.0 && !$0.1 }).bind(to: snowFlakeView.rx.isHidden).disposed(by: disposeBag)
+        isSnowFlake.map({ $0.0 || $0.1 }).bind(to: thumbnailImageView.rx.isHidden).disposed(by: disposeBag)
+
+        isSnowFlake.subscribe(onNext: { [weak self] (isLive: Bool, isLab: Bool) -> Void in
+            if isLive {
+                self?.snowFlakeView.image = #imageLiteral(resourceName: "live-indicator")
+            } else if isLab {
+                self?.snowFlakeView.image = #imageLiteral(resourceName: "lab-indicator")
+            }
+        }).disposed(by: disposeBag)
+
+        viewModel.rxImageUrl.distinctUntilChanged({ $0 != $1 }).subscribe(onNext: { [weak self] imageUrl in
+            guard let imageUrl = imageUrl else { return }
+
+            self?.imageDownloadOperation?.cancel()
+
+            self?.imageDownloadOperation = ImageDownloadCenter.shared.downloadImage(from: imageUrl, thumbnailHeight: Constants.thumbnailHeight) { [weak self] url, _, thumb in
+                guard url == imageUrl else { return }
+
+                self?.thumbnailImageView.image = thumb
+            }
+        }).disposed(by: disposeBag)
+
+        viewModel.rxColor.distinctUntilChanged({ $0 == $1 }).subscribe(onNext: { [weak self] color in
+            self?.contextColorView.color = color
+        }).disposed(by: disposeBag)
+
+        viewModel.rxDarkColor.distinctUntilChanged({ $0 == $1 }).subscribe(onNext: { [weak self] color in
+            self?.snowFlakeView.backgroundColor = color
+        }).disposed(by: disposeBag)
+
+        viewModel.rxProgresses.subscribe(onNext: { [weak self] progresses in
+            if let progress = progresses.first {
+                self?.contextColorView.hasValidProgress = true
+                self?.contextColorView.progress = progress.relativePosition
+            } else {
+                self?.contextColorView.hasValidProgress = false
+                self?.contextColorView.progress = 0
+            }
+        }).disposed(by: disposeBag)
+
+        viewModel.rxSessionType.distinctUntilChanged().subscribe(onNext: { [weak self] type in
+            guard type != .session && type != .lab else { return }
+
+            switch type {
+            case .getTogether:
+                self?.thumbnailImageView.image = #imageLiteral(resourceName: "get-together")
+            default:
+                self?.thumbnailImageView.image = #imageLiteral(resourceName: "special")
+            }
+        }).disposed(by: disposeBag)
+    }
+
+    private lazy var titleLabel: NSTextField = {
+        let l = NSTextField(labelWithString: "")
+        l.font = .systemFont(ofSize: 14, weight: .medium)
+        l.textColor = .primaryText
+        l.cell?.backgroundStyle = .dark
+        l.lineBreakMode = .byTruncatingTail
+
+        return l
+    }()
+
+    private lazy var subtitleLabel: NSTextField = {
+        let l = NSTextField(labelWithString: "")
+        l.font = .systemFont(ofSize: 12)
+        l.textColor = .secondaryText
+        l.cell?.backgroundStyle = .dark
+        l.lineBreakMode = .byTruncatingTail
+
+        return l
+    }()
+
+    private lazy var contextLabel: NSTextField = {
+        let l = NSTextField(labelWithString: "")
+        l.font = .systemFont(ofSize: 12)
+        l.textColor = .tertiaryText
+        l.cell?.backgroundStyle = .dark
+        l.lineBreakMode = .byTruncatingTail
+
+        return l
+    }()
+
+    private lazy var thumbnailImageView: WWDCImageView = {
+        let v = WWDCImageView()
+
+        v.heightAnchor.constraint(equalToConstant: 48).isActive = true
+        v.widthAnchor.constraint(equalToConstant: 85).isActive = true
+        v.backgroundColor = .black
+
+        return v
+    }()
+
+    private lazy var snowFlakeView: WWDCImageView = {
+        let v = WWDCImageView()
+
+        v.heightAnchor.constraint(equalToConstant: 48).isActive = true
+        v.widthAnchor.constraint(equalToConstant: 85).isActive = true
+        v.isHidden = true
+        v.image = #imageLiteral(resourceName: "lab-indicator")
+
+        return v
+    }()
+
+    private lazy var contextColorView: TrackColorView = {
+        let v = TrackColorView()
+
+        v.widthAnchor.constraint(equalToConstant: 4).isActive = true
+
+        return v
+    }()
+
+    private lazy var textStackView: NSStackView = {
+        let v = NSStackView(views: [self.titleLabel, self.subtitleLabel, self.contextLabel])
+
+        v.orientation = .vertical
+        v.alignment = .leading
+        v.distribution = .equalSpacing
+        v.spacing = 0
+
+        return v
+    }()
+
+    private lazy var favoritedImageView: WWDCImageView = {
+        let v = WWDCImageView()
+
+        v.heightAnchor.constraint(equalToConstant: 14).isActive = true
+        v.drawsBackground = false
+        v.image = #imageLiteral(resourceName: "star-small")
+
+        return v
+    }()
+
+    private lazy var downloadedImageView: WWDCImageView = {
+        let v = WWDCImageView()
+
+        v.heightAnchor.constraint(equalToConstant: 11).isActive = true
+        v.drawsBackground = false
+        v.image = #imageLiteral(resourceName: "download-small")
+
+        return v
+    }()
+
+    private lazy var iconsStackView: NSStackView = {
+        let v = NSStackView(views: [])
+
+        v.distribution = .gravityAreas
+        v.orientation = .vertical
+        v.spacing = 4
+        v.addView(self.favoritedImageView, in: .top)
+        v.addView(self.downloadedImageView, in: .bottom)
+        v.translatesAutoresizingMaskIntoConstraints = false
+
+        v.widthAnchor.constraint(equalToConstant: 12).isActive = true
+
+        return v
+    }()
+
+    private func buildUI() {
+        wantsLayer = true
+
+        contextColorView.translatesAutoresizingMaskIntoConstraints = false
+        thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
+        snowFlakeView.translatesAutoresizingMaskIntoConstraints = false
+        textStackView.translatesAutoresizingMaskIntoConstraints = false
+        iconsStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(contextColorView)
+        addSubview(thumbnailImageView)
+        addSubview(snowFlakeView)
+        addSubview(textStackView)
+        addSubview(iconsStackView)
+
+        contextColorView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10).isActive = true
+        contextColorView.topAnchor.constraint(equalTo: topAnchor, constant: 8).isActive = true
+        contextColorView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8).isActive = true
+
+        thumbnailImageView.centerYAnchor.constraint(equalTo: contextColorView.centerYAnchor).isActive = true
+        thumbnailImageView.leadingAnchor.constraint(equalTo: contextColorView.trailingAnchor, constant: 8).isActive = true
+        snowFlakeView.centerYAnchor.constraint(equalTo: thumbnailImageView.centerYAnchor).isActive = true
+        snowFlakeView.centerXAnchor.constraint(equalTo: thumbnailImageView.centerXAnchor).isActive = true
+
+        textStackView.centerYAnchor.constraint(equalTo: thumbnailImageView.centerYAnchor, constant: -1).isActive = true
+        textStackView.leadingAnchor.constraint(equalTo: thumbnailImageView.trailingAnchor, constant: 8).isActive = true
+        textStackView.trailingAnchor.constraint(equalTo: iconsStackView.leadingAnchor, constant: -2).isActive = true
+
+        iconsStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4).isActive = true
+        iconsStackView.topAnchor.constraint(equalTo: textStackView.topAnchor).isActive = true
+        iconsStackView.bottomAnchor.constraint(equalTo: textStackView.bottomAnchor).isActive = true
+
+        downloadedImageView.isHidden = true
+        favoritedImageView.isHidden = true
+    }
+    
+}

--- a/WWDC/SessionCollectionViewItem.swift
+++ b/WWDC/SessionCollectionViewItem.swift
@@ -24,7 +24,7 @@ final class SessionCollectionViewItem: NSCollectionViewItem {
         }
     }
 
-    var doubleClicked: ((SessionViewModel) -> Void)?
+    var onClicked: ((SessionViewModel) -> Void)?
 
     private lazy var cellView: SessionCellView = {
         return SessionCellView(frame: view.bounds)
@@ -38,9 +38,8 @@ final class SessionCollectionViewItem: NSCollectionViewItem {
         cellView.layer?.backgroundColor = NSColor.darkGridColor.cgColor
         cellView.layer?.cornerRadius = 5
 
-        let doubleClick = NSClickGestureRecognizer(target: self, action: #selector(doubleClickRecognized))
-        doubleClick.numberOfClicksRequired = 2
-        view.addGestureRecognizer(doubleClick)
+        let click = NSClickGestureRecognizer(target: self, action: #selector(clickRecognized))
+        view.addGestureRecognizer(click)
     }
 
     override func viewDidLoad() {
@@ -49,10 +48,10 @@ final class SessionCollectionViewItem: NSCollectionViewItem {
         setup()
     }
 
-    @objc private func doubleClickRecognized() {
+    @objc private func clickRecognized() {
         guard let viewModel = viewModel else { return }
 
-        doubleClicked?(viewModel)
+        onClicked?(viewModel)
     }
 
 }

--- a/WWDC/SessionCollectionViewItem.swift
+++ b/WWDC/SessionCollectionViewItem.swift
@@ -1,0 +1,58 @@
+//
+//  SessionCollectionViewItem.swift
+//  WWDC
+//
+//  Created by Guilherme Rambo on 13/05/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import Cocoa
+
+final class SessionCollectionViewItem: NSCollectionViewItem {
+
+    override func loadView() {
+        view = NSView()
+        view.wantsLayer = true
+    }
+
+    var viewModel: SessionViewModel? {
+        get {
+            return cellView.viewModel
+        }
+        set {
+            cellView.viewModel = newValue
+        }
+    }
+
+    var doubleClicked: ((SessionViewModel) -> Void)?
+
+    private lazy var cellView: SessionCellView = {
+        return SessionCellView(frame: view.bounds)
+    }()
+
+    private func setup() {
+        cellView.autoresizingMask = [.width, .height]
+        view.addSubview(cellView)
+        
+        cellView.layer?.masksToBounds = true
+        cellView.layer?.backgroundColor = NSColor.darkGridColor.cgColor
+        cellView.layer?.cornerRadius = 5
+
+        let doubleClick = NSClickGestureRecognizer(target: self, action: #selector(doubleClickRecognized))
+        doubleClick.numberOfClicksRequired = 2
+        view.addGestureRecognizer(doubleClick)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setup()
+    }
+
+    @objc private func doubleClickRecognized() {
+        guard let viewModel = viewModel else { return }
+
+        doubleClicked?(viewModel)
+    }
+
+}

--- a/WWDC/SessionCollectionViewItem.swift
+++ b/WWDC/SessionCollectionViewItem.swift
@@ -33,7 +33,7 @@ final class SessionCollectionViewItem: NSCollectionViewItem {
     private func setup() {
         cellView.autoresizingMask = [.width, .height]
         view.addSubview(cellView)
-        
+
         cellView.layer?.masksToBounds = true
         cellView.layer?.backgroundColor = NSColor.darkGridColor.cgColor
         cellView.layer?.cornerRadius = 5

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -12,6 +12,10 @@ import RxCocoa
 
 class SessionDetailsViewController: NSViewController {
 
+    private struct Metrics {
+        static let padding: CGFloat = 22
+    }
+
     private let disposeBag = DisposeBag()
 
     let listStyle: SessionsListStyle
@@ -175,7 +179,7 @@ class SessionDetailsViewController: NSViewController {
     }()
 
     private lazy var informationStackViewBottomConstraint: NSLayoutConstraint = {
-        return self.informationStackView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -46)
+        return self.informationStackView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -Metrics.padding)
     }()
 
     override func loadView() {
@@ -194,12 +198,12 @@ class SessionDetailsViewController: NSViewController {
         view.addSubview(shelfController.view)
         view.addSubview(informationStackView)
 
-        shelfController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 46).isActive = true
-        shelfController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -46).isActive = true
+        shelfController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.padding).isActive = true
+        shelfController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.padding).isActive = true
         shelfController.view.topAnchor.constraint(equalTo: view.topAnchor, constant: 22).isActive = true
 
-        informationStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 46).isActive = true
-        informationStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -46).isActive = true
+        informationStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.padding).isActive = true
+        informationStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.padding).isActive = true
         informationStackViewBottomConstraint.isActive = true
 
         shelfBottomConstraint.isActive = true

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -18,7 +18,6 @@ class SessionDetailsViewController: NSViewController {
 
     var viewModel: SessionViewModel? = nil {
         didSet {
-
             view.animator().alphaValue = (viewModel == nil) ? 0 : 1
 
             shelfController.viewModel = viewModel
@@ -30,7 +29,6 @@ class SessionDetailsViewController: NSViewController {
             }
 
             if viewModel.identifier != oldValue?.identifier {
-
                 showOverview()
             }
 
@@ -49,7 +47,6 @@ class SessionDetailsViewController: NSViewController {
             // It's worth noting that this condition will always be true since the view
             // gets loaded when add to the split view controller
             if isViewLoaded {
-
                 // Connect stack view (bottom half of screen), to the top of the view
                 // or to the bottom of the video, if it's present
                 shelfBottomConstraint.isActive = !sessionHasNoVideo

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -13,7 +13,7 @@ import RxCocoa
 class SessionDetailsViewController: NSViewController {
 
     private struct Metrics {
-        static let padding: CGFloat = 22
+        static let padding: CGFloat = 46
     }
 
     private let disposeBag = DisposeBag()

--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -49,6 +49,10 @@ class SessionSummaryViewController: NSViewController {
         return v
     }()
 
+    lazy var relatedSessionsViewController: RelatedSessionsViewController = {
+        return RelatedSessionsViewController()
+    }()
+
     private lazy var summaryLabel: WWDCTextField = {
         let l = WWDCTextField(labelWithString: "")
         l.font = .systemFont(ofSize: 18)
@@ -108,6 +112,13 @@ class SessionSummaryViewController: NSViewController {
         stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+
+        addChildViewController(relatedSessionsViewController)
+        relatedSessionsViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(relatedSessionsViewController.view)
+        relatedSessionsViewController.view.heightAnchor.constraint(equalToConstant: RelatedSessionsViewController.Metrics.height).isActive = true
+        relatedSessionsViewController.view.leadingAnchor.constraint(equalTo: stackView.leadingAnchor).isActive = true
+        relatedSessionsViewController.view.trailingAnchor.constraint(equalTo: stackView.trailingAnchor).isActive = true
     }
 
     override func viewDidLoad() {
@@ -121,6 +132,9 @@ class SessionSummaryViewController: NSViewController {
         actionsViewController.viewModel = viewModel
 
         guard let viewModel = viewModel else { return }
+
+        let relatedSessions = viewModel.session.related.compactMap({ $0.session })
+        relatedSessionsViewController.sessions = relatedSessions.compactMap(SessionViewModel.init)
 
         disposeBag = DisposeBag()
 

--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -150,6 +150,8 @@ class SessionSummaryViewController: NSViewController {
             let relatedSessions = relatedResources.compactMap({ $0.session })
             self?.relatedSessionsViewController.sessions = relatedSessions.compactMap(SessionViewModel.init)
         }).disposed(by: disposeBag)
+
+        relatedSessionsViewController.scrollToBeginningOfDocument(nil)
     }
 
 }

--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import RxSwift
 import RxCocoa
+import ConfCore
 
 class SessionSummaryViewController: NSViewController {
 
@@ -50,7 +51,11 @@ class SessionSummaryViewController: NSViewController {
     }()
 
     lazy var relatedSessionsViewController: RelatedSessionsViewController = {
-        return RelatedSessionsViewController()
+        let c = RelatedSessionsViewController()
+
+        c.title = "Related Sessions"
+
+        return c
     }()
 
     private lazy var summaryLabel: WWDCTextField = {
@@ -133,9 +138,6 @@ class SessionSummaryViewController: NSViewController {
 
         guard let viewModel = viewModel else { return }
 
-        let relatedSessions = viewModel.session.related.compactMap({ $0.session })
-        relatedSessionsViewController.sessions = relatedSessions.compactMap(SessionViewModel.init)
-
         disposeBag = DisposeBag()
 
         viewModel.rxTitle.map(NSAttributedString.attributedBoldTitle(with:)).subscribe(onNext: { [weak self] title in
@@ -143,6 +145,11 @@ class SessionSummaryViewController: NSViewController {
         }).disposed(by: disposeBag)
         viewModel.rxSummary.bind(to: summaryLabel.rx.text).disposed(by: disposeBag)
         viewModel.rxFooter.bind(to: contextLabel.rx.text).disposed(by: disposeBag)
+
+        viewModel.rxRelatedSessions.subscribe(onNext: { [weak self] relatedResources in
+            let relatedSessions = relatedResources.compactMap({ $0.session })
+            self?.relatedSessionsViewController.sessions = relatedSessions.compactMap(SessionViewModel.init)
+        }).disposed(by: disposeBag)
     }
 
 }

--- a/WWDC/SessionTableCellView.swift
+++ b/WWDC/SessionTableCellView.swift
@@ -12,244 +12,32 @@ import RxCocoa
 
 final class SessionTableCellView: NSTableCellView {
 
-    private var disposeBag = DisposeBag()
-
-    var viewModel: SessionViewModel? {
-        didSet {
-            guard viewModel !== oldValue else { return }
-
-            thumbnailImageView.image = #imageLiteral(resourceName: "noimage")
-            bindUI()
-        }
-    }
-
-    private weak var imageDownloadOperation: Operation?
-
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
 
-        buildUI()
+        setup()
     }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    var viewModel: SessionViewModel? {
+        get {
+            return cellView.viewModel
+        }
+        set {
+            cellView.viewModel = newValue
+        }
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
-        imageDownloadOperation?.cancel()
-
-        downloadedImageView.isHidden = true
-        favoritedImageView.isHidden = true
+    required init?(coder decoder: NSCoder) {
+        fatalError()
     }
 
-    private func bindUI() {
-        disposeBag = DisposeBag()
-
-        guard let viewModel = viewModel else { return }
-
-        viewModel.rxTitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(titleLabel.rx.text).disposed(by: disposeBag)
-        viewModel.rxSubtitle.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(subtitleLabel.rx.text).disposed(by: disposeBag)
-        viewModel.rxContext.distinctUntilChanged().asDriver(onErrorJustReturn: "").drive(contextLabel.rx.text).disposed(by: disposeBag)
-
-        viewModel.rxIsFavorite.distinctUntilChanged().map({ !$0 }).bind(to: favoritedImageView.rx.isHidden).disposed(by: disposeBag)
-        viewModel.rxIsDownloaded.distinctUntilChanged().map({ !$0 }).bind(to: downloadedImageView.rx.isHidden).disposed(by: disposeBag)
-
-        let isSnowFlake = Observable.zip(viewModel.rxIsCurrentlyLive, viewModel.rxIsLab)
-
-        isSnowFlake.map({ !$0.0 && !$0.1 }).bind(to: snowFlakeView.rx.isHidden).disposed(by: disposeBag)
-        isSnowFlake.map({ $0.0 || $0.1 }).bind(to: thumbnailImageView.rx.isHidden).disposed(by: disposeBag)
-
-        isSnowFlake.subscribe(onNext: { [weak self] (isLive: Bool, isLab: Bool) -> Void in
-            if isLive {
-                self?.snowFlakeView.image = #imageLiteral(resourceName: "live-indicator")
-            } else if isLab {
-                self?.snowFlakeView.image = #imageLiteral(resourceName: "lab-indicator")
-            }
-        }).disposed(by: disposeBag)
-
-        viewModel.rxImageUrl.distinctUntilChanged({ $0 != $1 }).subscribe(onNext: { [weak self] imageUrl in
-            guard let imageUrl = imageUrl else { return }
-
-            self?.imageDownloadOperation?.cancel()
-
-            self?.imageDownloadOperation = ImageDownloadCenter.shared.downloadImage(from: imageUrl, thumbnailHeight: Constants.thumbnailHeight) { [weak self] url, _, thumb in
-                guard url == imageUrl else { return }
-
-                self?.thumbnailImageView.image = thumb
-            }
-        }).disposed(by: disposeBag)
-
-        viewModel.rxColor.distinctUntilChanged({ $0 == $1 }).subscribe(onNext: { [weak self] color in
-            self?.contextColorView.color = color
-        }).disposed(by: disposeBag)
-
-        viewModel.rxDarkColor.distinctUntilChanged({ $0 == $1 }).subscribe(onNext: { [weak self] color in
-            self?.snowFlakeView.backgroundColor = color
-        }).disposed(by: disposeBag)
-
-        viewModel.rxProgresses.subscribe(onNext: { [weak self] progresses in
-            if let progress = progresses.first {
-                self?.contextColorView.hasValidProgress = true
-                self?.contextColorView.progress = progress.relativePosition
-            } else {
-                self?.contextColorView.hasValidProgress = false
-                self?.contextColorView.progress = 0
-            }
-        }).disposed(by: disposeBag)
-
-        viewModel.rxSessionType.distinctUntilChanged().subscribe(onNext: { [weak self] type in
-            guard type != .session && type != .lab else { return }
-
-            switch type {
-            case .getTogether:
-                self?.thumbnailImageView.image = #imageLiteral(resourceName: "get-together")
-            default:
-                self?.thumbnailImageView.image = #imageLiteral(resourceName: "special")
-            }
-        }).disposed(by: disposeBag)
-    }
-
-    private lazy var titleLabel: NSTextField = {
-        let l = NSTextField(labelWithString: "")
-        l.font = .systemFont(ofSize: 14, weight: .medium)
-        l.textColor = .primaryText
-        l.cell?.backgroundStyle = .dark
-        l.lineBreakMode = .byTruncatingTail
-
-        return l
+    private lazy var cellView: SessionCellView = {
+        return SessionCellView(frame: bounds)
     }()
 
-    private lazy var subtitleLabel: NSTextField = {
-        let l = NSTextField(labelWithString: "")
-        l.font = .systemFont(ofSize: 12)
-        l.textColor = .secondaryText
-        l.cell?.backgroundStyle = .dark
-        l.lineBreakMode = .byTruncatingTail
-
-        return l
-    }()
-
-    private lazy var contextLabel: NSTextField = {
-        let l = NSTextField(labelWithString: "")
-        l.font = .systemFont(ofSize: 12)
-        l.textColor = .tertiaryText
-        l.cell?.backgroundStyle = .dark
-        l.lineBreakMode = .byTruncatingTail
-
-        return l
-    }()
-
-    private lazy var thumbnailImageView: WWDCImageView = {
-        let v = WWDCImageView()
-
-        v.heightAnchor.constraint(equalToConstant: 48).isActive = true
-        v.widthAnchor.constraint(equalToConstant: 85).isActive = true
-        v.backgroundColor = .black
-
-        return v
-    }()
-
-    private lazy var snowFlakeView: WWDCImageView = {
-        let v = WWDCImageView()
-
-        v.heightAnchor.constraint(equalToConstant: 48).isActive = true
-        v.widthAnchor.constraint(equalToConstant: 85).isActive = true
-        v.isHidden = true
-        v.image = #imageLiteral(resourceName: "lab-indicator")
-
-        return v
-    }()
-
-    private lazy var contextColorView: TrackColorView = {
-        let v = TrackColorView()
-
-        v.widthAnchor.constraint(equalToConstant: 4).isActive = true
-
-        return v
-    }()
-
-    private lazy var textStackView: NSStackView = {
-        let v = NSStackView(views: [self.titleLabel, self.subtitleLabel, self.contextLabel])
-
-        v.orientation = .vertical
-        v.alignment = .leading
-        v.distribution = .equalSpacing
-        v.spacing = 0
-
-        return v
-    }()
-
-    private lazy var favoritedImageView: WWDCImageView = {
-        let v = WWDCImageView()
-
-        v.heightAnchor.constraint(equalToConstant: 14).isActive = true
-        v.drawsBackground = false
-        v.image = #imageLiteral(resourceName: "star-small")
-
-        return v
-    }()
-
-    private lazy var downloadedImageView: WWDCImageView = {
-        let v = WWDCImageView()
-
-        v.heightAnchor.constraint(equalToConstant: 11).isActive = true
-        v.drawsBackground = false
-        v.image = #imageLiteral(resourceName: "download-small")
-
-        return v
-    }()
-
-    private lazy var iconsStackView: NSStackView = {
-        let v = NSStackView(views: [])
-
-        v.distribution = .gravityAreas
-        v.orientation = .vertical
-        v.spacing = 4
-        v.addView(self.favoritedImageView, in: .top)
-        v.addView(self.downloadedImageView, in: .bottom)
-        v.translatesAutoresizingMaskIntoConstraints = false
-
-        v.widthAnchor.constraint(equalToConstant: 12).isActive = true
-
-        return v
-    }()
-
-    private func buildUI() {
-        wantsLayer = true
-
-        contextColorView.translatesAutoresizingMaskIntoConstraints = false
-        thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
-        snowFlakeView.translatesAutoresizingMaskIntoConstraints = false
-        textStackView.translatesAutoresizingMaskIntoConstraints = false
-        iconsStackView.translatesAutoresizingMaskIntoConstraints = false
-
-        addSubview(contextColorView)
-        addSubview(thumbnailImageView)
-        addSubview(snowFlakeView)
-        addSubview(textStackView)
-        addSubview(iconsStackView)
-
-        contextColorView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10).isActive = true
-        contextColorView.topAnchor.constraint(equalTo: topAnchor, constant: 8).isActive = true
-        contextColorView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8).isActive = true
-
-        thumbnailImageView.centerYAnchor.constraint(equalTo: contextColorView.centerYAnchor).isActive = true
-        thumbnailImageView.leadingAnchor.constraint(equalTo: contextColorView.trailingAnchor, constant: 8).isActive = true
-        snowFlakeView.centerYAnchor.constraint(equalTo: thumbnailImageView.centerYAnchor).isActive = true
-        snowFlakeView.centerXAnchor.constraint(equalTo: thumbnailImageView.centerXAnchor).isActive = true
-
-        textStackView.centerYAnchor.constraint(equalTo: thumbnailImageView.centerYAnchor, constant: -1).isActive = true
-        textStackView.leadingAnchor.constraint(equalTo: thumbnailImageView.trailingAnchor, constant: 8).isActive = true
-        textStackView.trailingAnchor.constraint(equalTo: iconsStackView.leadingAnchor, constant: -2).isActive = true
-
-        iconsStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4).isActive = true
-        iconsStackView.topAnchor.constraint(equalTo: textStackView.topAnchor).isActive = true
-        iconsStackView.bottomAnchor.constraint(equalTo: textStackView.bottomAnchor).isActive = true
-
-        downloadedImageView.isHidden = true
-        favoritedImageView.isHidden = true
+    private func setup() {
+        cellView.autoresizingMask = [.width, .height]
+        addSubview(cellView)
     }
 
 }

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -131,6 +131,14 @@ final class SessionViewModel {
         return Observable.collection(from: progresses)
     }()
 
+    lazy var rxRelatedSessions: Observable<Results<RelatedResource>> = {
+        let predicateFormat = "type == %@ AND (ANY session.instances.sessionType == %d OR ANY session.instances.startTime >= %@)"
+        let relatedPredicate = NSPredicate(format: predicateFormat, RelatedResourceType.session.rawValue, SessionInstanceType.session.rawValue, today() as NSDate)
+        let validRelatedSessions = self.session.related.filter(relatedPredicate)
+
+        return Observable.collection(from: validRelatedSessions)
+    }()
+
     convenience init?(session: Session) {
         self.init(session: session, instance: nil, style: .videos)
     }


### PR DESCRIPTION
This is the first part of the UI side for #367 (issue #331). I've implemented the collection of related sessions at the bottom of the session details following @VicenteBorrell's design.

Some details on how the app decides which sessions to show:
- It only shows labs if their start time is greater than or equal to the current time (there's no need to show past labs)
- Items have to be double-clicked to go to the related session, single-click was too easy to select by accident
- When an item is selected in the videos tab that's not available in that tab (for instance, a lab), the app will switch to the schedule tab with the item selected

Even though this is only the related sessions portion of the implementation, it can already be merged. I'm going to implement the other related resources (documentation, sample code, etc) in another branch.

<img width="1240" alt="screen shot 2018-05-17 at 22 52 36" src="https://user-images.githubusercontent.com/67184/40212285-a1ecbb1a-5a25-11e8-92bb-0134deb23e97.png">
