### PR TITLE
Pointing to new API endpoint

### DIFF
--- a/ConfCore/Environment.swift
+++ b/ConfCore/Environment.swift
@@ -90,7 +90,7 @@ extension Environment {
                                          newsPath: "/news.json",
                                          liveVideosPath: "/videos_live.json")
 
-    public static let production = Environment(baseURL: "https://api2017.wwdc.io",
+    public static let production = Environment(baseURL: "https://api2018.wwdc.io",
                                                videosPath: "/videos.json",
                                                sessionsPath: "/contents.json",
                                                newsPath: "/news.json",


### PR DESCRIPTION
As mentioned in #376, we would like to be able to add our own content to playlists in the future.

This PR changes the API endpoint from `api2017.wwdc.io`, which was a redirect hosted on a DigitalOcean server sending all requests directly to Apple's API, to `api2018.wwdc.io`, which is powered by CloudFlare and will allow us to modify the original response if we want to.

This could also be a good way to fix incompatibilities that can arise from Apple changing their API, we can translate between their API and what we expect using the worker instead of changing code in the app itself.