### PR TITLE
Implemented session action links

### DIFF
--- a/ConfCore/SessionInstance.swift
+++ b/ConfCore/SessionInstance.swift
@@ -98,6 +98,10 @@ public class SessionInstance: Object {
     /// See https://developer.apple.com/reference/eventkit/ekevent/1507437-eventidentifier
     @objc public dynamic var calendarEventIdentifier = ""
 
+    // Action link
+    @objc public dynamic var actionLinkPrompt: String?
+    @objc public dynamic var actionLinkURL: String?
+
     public override static func primaryKey() -> String? {
         return "identifier"
     }

--- a/ConfCore/SessionInstancesJSONAdapter.swift
+++ b/ConfCore/SessionInstancesJSONAdapter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyJSON
 
 enum SessionInstanceKeys: String, JSONSubscriptType {
-    case id, keywords, startTime, endTime, type, eventId
+    case id, keywords, startTime, endTime, type, eventId, actionLinkPrompt, actionLinkURL
     case favId = "fav_id"
     case room = "roomId"
     case track = "trackId"
@@ -84,6 +84,8 @@ final class SessionInstancesJSONAdapter: Adapter {
         instance.sessionType = SessionInstanceType(rawSessionType: rawType)?.rawValue ?? 0
         instance.startTime = startDate
         instance.endTime = endDate
+        instance.actionLinkPrompt = input[SessionInstanceKeys.actionLinkPrompt].string
+        instance.actionLinkURL = input[SessionInstanceKeys.actionLinkURL].string
 
         return .success(instance)
     }

--- a/ConfCoreTests/AdapterTests.swift
+++ b/ConfCoreTests/AdapterTests.swift
@@ -305,6 +305,8 @@ class AdapterTests: XCTestCase {
             XCTAssertEqual(instances[0].keywords.count, 0)
             XCTAssertEqual(instances[0].startTime, dateTimeFormatter.date(from: "2017-06-09T09:00:00-07:00"))
             XCTAssertEqual(instances[0].endTime, dateTimeFormatter.date(from: "2017-06-09T15:30:00-07:00"))
+            XCTAssertEqual(instances[0].actionLinkPrompt, "Request appointment")
+            XCTAssertEqual(instances[0].actionLinkURL, "https://developer.apple.com/go/?id=wwdc-consultations")
 
             // Session
             XCTAssertNotNil(instances[2].session)

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
@@ -109,7 +109,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "2017-06-05T15:00:00-03:00"
+            argument = "2018-06-04T10:00:00-07:00"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Constants {
 
-    static let coreSchemaVersion: UInt64 = 38
+    static let coreSchemaVersion: UInt64 = 42
 
     static let thumbnailHeight: CGFloat = 150
 

--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -83,8 +83,29 @@ class SessionSummaryViewController: NSViewController {
         return l
     }()
 
+    private lazy var actionLinkLabel: ActionLabel = {
+        let l = ActionLabel(labelWithString: "")
+
+        l.font = .systemFont(ofSize: 16)
+        l.textColor = .primary
+        l.target = self
+        l.action = #selector(clickedActionLabel)
+
+        return l
+    }()
+
+    private lazy var contextStackView: NSStackView = {
+        let v = NSStackView(views: [self.contextLabel, self.actionLinkLabel])
+
+        v.orientation = .horizontal
+        v.spacing = 16
+        v.translatesAutoresizingMaskIntoConstraints = false
+
+        return v
+    }()
+
     private lazy var stackView: NSStackView = {
-        let v = NSStackView(views: [self.summaryLabel, self.contextLabel])
+        let v = NSStackView(views: [self.summaryLabel, self.contextStackView])
 
         v.orientation = .vertical
         v.alignment = .leading
@@ -152,6 +173,14 @@ class SessionSummaryViewController: NSViewController {
         }).disposed(by: disposeBag)
 
         relatedSessionsViewController.scrollToBeginningOfDocument(nil)
+
+        viewModel.rxActionPrompt.bind(to: actionLinkLabel.rx.text).disposed(by: disposeBag)
+    }
+
+    @objc private func clickedActionLabel() {
+        guard let url = viewModel?.actionLinkURL else { return }
+
+        NSWorkspace.shared.open(url)
     }
 
 }

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -48,6 +48,7 @@ final class SessionViewModel {
     }()
 
     lazy var rxActionPrompt: Observable<String?> = {
+        guard sessionInstance.startTime > today() else { return Observable.just(nil) }
         guard actionLinkURL != nil else { return Observable.just(nil) }
 
         return Observable.from(object: self.sessionInstance).map({ $0.actionLinkPrompt })

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -47,6 +47,18 @@ final class SessionViewModel {
         return Observable.from(object: self.session).map({ $0.summary })
     }()
 
+    lazy var rxActionPrompt: Observable<String?> = {
+        guard actionLinkURL != nil else { return Observable.just(nil) }
+
+        return Observable.from(object: self.sessionInstance).map({ $0.actionLinkPrompt })
+    }()
+
+    var actionLinkURL: URL? {
+        guard let candidateURL = sessionInstance.actionLinkURL else { return nil }
+
+        return URL(string: candidateURL)
+    }
+
     lazy var rxContext: Observable<String> = {
         if self.style == .schedule {
             let so = Observable.from(object: self.session)


### PR DESCRIPTION
Some labs and special events have action links associated with them to get directions to a place or schedule an appointment. This adds support for that, displaying the link in the summary view footer.

<img width="1172" alt="screen shot 2018-05-26 at 13 51 27" src="https://user-images.githubusercontent.com/67184/40578569-5dc44638-60ec-11e8-917b-f2c168171c55.png">

<img width="1172" alt="screen shot 2018-05-26 at 13 52 26" src="https://user-images.githubusercontent.com/67184/40578570-5de0ef4a-60ec-11e8-9ab5-3c7bf89c2501.png">
