### PR TITLE
Check for explicit field editors

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1115,8 +1115,10 @@ public final class PUIPlayerView: NSView {
                 return event
             }
 
-            // ignore keystrokes when editing text
-            guard !(self.window?.firstResponder is NSTextView) else { return event }
+            let allWindows = NSApp.windows
+            let firstResponders = allWindows.compactMap { $0.firstResponder }
+            let fieldEditors = firstResponders.filter { ($0 as? NSText)?.isFieldEditor == true }
+            guard fieldEditors.isEmpty else { return event }
             guard !self.timelineView.isEditingAnnotation else { return event }
 
             switch command {


### PR DESCRIPTION
The problem with the code is that it's only checking a single window for an `NSTextView`. In the case (for example) when the player has popped out to the PIP window, then weird things happen.

So instead, we'll simply check all windows to see if any of them has an active field editor. If one does, then we'll defer and let that field editor handle the space. If no window is actively editing text (ie, there is no field editor), then we'll process the space key as the play/pause toggle.