### PR TITLE
Fixed subtitle for the "Fall 2017" event in sidebar

### DIFF
--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -179,7 +179,12 @@ final class SessionViewModel {
 
         let year = Calendar.current.component(.year, from: event.startDate)
 
-        return "WWDC \(year) · Session \(session.number)"
+        // Currently, there's only one event which is not a WWDC (the "Fall 2017" event),
+        // for some reason it includes the year on its name, while WWDC editions do not,
+        // so we have to use this workaround to avoid displaying the year twice
+        let name = event.name.replacingOccurrences(of: " \(year)", with: "")
+
+        return "\(name) \(year) · Session \(session.number)"
     }
 
     static func focusesDescription(from focuses: [Focus], collapse: Bool) -> String {


### PR DESCRIPTION
Videos from the "Fall 2017" event were showing "WWDC 2017" in the subtitle, this fixes that by using the event name to compose the subtitle. I had to do a workaround because the Fall 2017 event includes the year on its title while WWDC editions do not.