### PR TITLE
Fixes some layout and scrolling issues on playlists

### DIFF
--- a/WWDC/FeaturedContentCollectionViewCell.swift
+++ b/WWDC/FeaturedContentCollectionViewCell.swift
@@ -34,11 +34,12 @@ final class FeaturedContentCollectionViewItem: NSCollectionViewItem {
         static let width: CGFloat = 340
         static let height: CGFloat = 252
         static let imageHeight: CGFloat = 192
+        static let imageAspectRatio: CGFloat = 9 / 16
         static let imageRadius: CGFloat = 6
     }
 
     override func loadView() {
-        view = NSView(frame: NSRect(x: 0, y: 0, width: Metrics.width, height: Metrics.height))
+        view = NSView(frame: .zero)
         view.wantsLayer = true
 
         buildUI()
@@ -50,8 +51,9 @@ final class FeaturedContentCollectionViewItem: NSCollectionViewItem {
     private lazy var thumbnailImageView: WWDCImageView = {
         let v = WWDCImageView()
 
-        v.heightAnchor.constraint(equalToConstant: Metrics.imageHeight).isActive = true
-        v.widthAnchor.constraint(equalToConstant: Metrics.width).isActive = true
+        let aspectRatioConstraint = v.heightAnchor.constraint(equalTo: v.widthAnchor, multiplier: Metrics.imageAspectRatio)
+        aspectRatioConstraint.priority = NSLayoutConstraint.Priority(rawValue: 750)
+        aspectRatioConstraint.isActive = true
         v.backgroundColor = .black
 
         return v

--- a/WWDC/FeaturedContentViewController.swift
+++ b/WWDC/FeaturedContentViewController.swift
@@ -32,10 +32,15 @@ final class FeaturedContentViewController: NSViewController {
     private lazy var scrollView: NSScrollView = {
         let v = NSScrollView(frame: view.bounds)
 
+        v.autoresizingMask = [.width, .height]
+        v.contentView = FlippedClipView()
         v.hasVerticalScroller = true
-        v.hasHorizontalScroller = false
+        v.backgroundColor = .listBackground
+        v.autohidesScrollers = true
+        v.horizontalScrollElasticity = .none
         v.automaticallyAdjustsContentInsets = false
         v.contentInsets = NSEdgeInsets(top: 0, left: 0, bottom: FeaturedSectionViewController.Metrics.padding, right: 0)
+        v.scrollerInsets = NSEdgeInsets(top: 0, left: 0, bottom: -FeaturedSectionViewController.Metrics.padding, right: 0)
 
         return v
     }()
@@ -43,7 +48,6 @@ final class FeaturedContentViewController: NSViewController {
     private lazy var stackView: NSStackView = {
         let v = NSStackView(views: [])
 
-        v.autoresizingMask = [.width, .height]
         v.spacing = 24
         v.orientation = .vertical
         v.alignment = .leading
@@ -53,20 +57,19 @@ final class FeaturedContentViewController: NSViewController {
     }()
 
     override func loadView() {
-        view = NSView()
+        // This is a visual effect view to allow the scrollers to appear correctly
+        view = NSVisualEffectView()
         view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.listBackground.cgColor
 
-        scrollView.frame = view.bounds
-        scrollView.autoresizingMask = [.width, .height]
         view.addSubview(scrollView)
 
-        stackView.frame = scrollView.bounds
-        scrollView.contentView = FlippedClipView()
-        scrollView.backgroundColor = .listBackground
         scrollView.documentView = stackView
 
-        stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor).isActive = true
+        let clipView = scrollView.contentView
+        stackView.topAnchor.constraint(equalTo: clipView.topAnchor).isActive = true
+        stackView.trailingAnchor.constraint(equalTo: clipView.trailingAnchor).isActive = true
+        stackView.widthAnchor.constraint(equalTo: clipView.widthAnchor).isActive = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
     }
 
     override func viewDidLoad() {

--- a/WWDC/FeaturedSectionViewController.swift
+++ b/WWDC/FeaturedSectionViewController.swift
@@ -104,6 +104,11 @@ final class FeaturedSectionViewController: NSViewController {
 
         v.hasHorizontalScroller = true
         v.horizontalScroller?.alphaValue = 0
+        v.scrollerStyle = .overlay
+
+        _ = NotificationCenter.default.addObserver(forName: NSScroller.preferredScrollerStyleDidChangeNotification, object: nil, queue: nil) { [weak v] _ in
+            v?.scrollerStyle = .overlay
+        }
 
         return v
     }()
@@ -124,7 +129,7 @@ final class FeaturedSectionViewController: NSViewController {
         v.collectionViewLayout = layout
         v.dataSource = self
         v.delegate = self
-        v.autoresizingMask = [.width, .minYMargin]
+        v.autoresizingMask = [.width, .height]
         v.backgroundColors = [NSColor.listBackground]
 
         return v
@@ -155,6 +160,13 @@ final class FeaturedSectionViewController: NSViewController {
 
         collectionView.register(FeaturedContentCollectionViewItem.self, forItemWithIdentifier: .featuredContentItem)
         bindUI()
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+
+        // https://stackoverflow.com/questions/46433652/nscollectionview-does-not-scroll-items-past-initial-visible-rect
+        collectionView.setFrameSize(collectionView.collectionViewLayout!.collectionViewContentSize)
     }
 
     override func scrollToBeginningOfDocument(_ sender: Any?) {


### PR DESCRIPTION
Addresses:
1. Vertical scroller would disappear when set to always visible
2. Collection views would get messed up if scrollers set to always visible
3. Bottom padding of page caused scroller to not reach bottom
4. Collection views weren't scrollable until SOMETHING happens, such as window resize or contents get changed
5. Outer scroll view bounced horizontally if your mouse wasn't over a collection view