### PR TITLE
Added argument to use a custom environment

### DIFF
--- a/ConfCore/Environment.swift
+++ b/ConfCore/Environment.swift
@@ -77,6 +77,16 @@ extension Environment {
     }
 
     public static var current: Environment {
+        #if DEBUG
+        if let baseURL = UserDefaults.standard.string(forKey: "WWDCEnvironmentBaseURL") {
+            return Environment(baseURL: baseURL,
+                               videosPath: "/videos.json",
+                               sessionsPath: "/contents.json",
+                               newsPath: "/news.json",
+                               liveVideosPath: "/videos_live.json",
+                               featuredSectionsPath: "/_featured.json")
+        }
+        #endif
         if ProcessInfo.processInfo.arguments.contains("--test") {
             return .test
         } else {

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC with iCloud.xcscheme
@@ -77,12 +77,16 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-WWDCEnvironmentBaseURL https://wwdc-staging.orangebox.app"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--enable-updates"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-WWDCUseDebugStorage YES"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-transcripts"


### PR DESCRIPTION
I set up a staging environment on CloudFlare to do tests before deploying changes to the live worker, so I added a new argument that allows to specify a custom base URL for the environment in debug builds.