### PR TITLE
Improved handling of live sessions

### DIFF
--- a/ConfCore/AppleAPIClient.swift
+++ b/ConfCore/AppleAPIClient.swift
@@ -157,7 +157,7 @@ public final class AppleAPIClient {
         }
 
         currentLiveVideosRequest?.cancel()
-        currentLiveVideosRequest = liveVideoAssetsResource.loadIfNeeded()
+        currentLiveVideosRequest = liveVideoAssetsResource.load()
     }
 
     public func fetchContent(completion: @escaping (Result<ContentsResponse, APIError>) -> Void) {

--- a/ConfCore/LiveVideosAdapter.swift
+++ b/ConfCore/LiveVideosAdapter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyJSON
 
 private enum LiveVideoKeys: String, JSONSubscriptType {
-    case sessionId, tvosUrl, iosUrl
+    case sessionId, tvosUrl, iosUrl, actualEndDate
 
     var jsonKey: JSONKey {
         return JSONKey.key(rawValue)
@@ -34,9 +34,19 @@ final class LiveVideosAdapter: Adapter {
         let asset = SessionAsset()
         // Live assets are always for the current year
         asset.year = Calendar.current.component(.year, from: Date())
-        asset.sessionId = sessionId
+
+        // There are two assumptions being made here
+        // 1 - Live assets are always for the current year
+        // 2 - Live assets are always for "WWDC" events
+        // FIXME: done in a rush to fix live streaming in 2018
+        asset.sessionId = "wwdc\(asset.year)-"+sessionId
         asset.rawAssetType = SessionAssetType.liveStreamVideo.rawValue
         asset.remoteURL = url
+
+        if let rawEndDate = input[LiveVideoKeys.actualEndDate].string,
+            case .success(let actualEndDate) = DateTimeAdapter().adapt(rawEndDate) {
+            asset.actualEndDate = actualEndDate
+        }
 
         return .success(asset)
     }

--- a/ConfCore/SessionAsset.swift
+++ b/ConfCore/SessionAsset.swift
@@ -68,6 +68,8 @@ public class SessionAsset: Object {
     /// Relative local URL to save the asset to when downloading
     @objc public dynamic var relativeLocalURL = ""
 
+    @objc public dynamic var actualEndDate: Date?
+
     /// The session this asset belongs to
     public let session = LinkingObjects(fromType: Session.self, property: "assets")
 

--- a/ConfCore/StorageMigrator.swift
+++ b/ConfCore/StorageMigrator.swift
@@ -27,7 +27,8 @@ final class StorageMigrator {
         32: migrateSessionModels,
         34: migrateOldTranscriptModels,
         37: migrateIdentifiersWithoutReplacement,
-        43: migrateTracks
+        43: migrateTracks,
+        44: removeInvalidLiveAssets
     ]
 
     init(migration: Migration, oldVersion: UInt64) {
@@ -164,6 +165,17 @@ final class StorageMigrator {
         os_log("migrateTracks", log: log, type: .info)
 
         migration.deleteData(forType: "Track")
+    }
+
+    private static func removeInvalidLiveAssets(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("removeInvalidLiveAssets", log: log, type: .info)
+
+        // Delete invalid live streaming assets
+        migration.enumerateObjects(ofType: "SessionAsset") { _, asset in
+            guard let asset = asset else { return }
+            guard asset["rawAssetType"] as? String == "WWDCSessionAssetTypeLiveStreamVideo" else { return }
+            migration.delete(asset)
+        }
     }
 
 }

--- a/ConfCore/SyncEngine.swift
+++ b/ConfCore/SyncEngine.swift
@@ -69,10 +69,11 @@ public final class SyncEngine {
         }
     }
 
-    public func syncLiveVideos() {
+    public func syncLiveVideos(completion: (() -> Void)? = nil) {
         client.fetchLiveVideoAssets { [weak self] result in
             DispatchQueue.main.async {
                 self?.storage.store(liveVideosResult: result)
+                completion?()
             }
         }
     }

--- a/ConfCoreTests/AdapterTests.swift
+++ b/ConfCoreTests/AdapterTests.swift
@@ -242,7 +242,7 @@ class AdapterTests: XCTestCase {
             let sortedAssets = assets.sorted(by: { $0.sessionId < $1.sessionId })
             XCTAssertEqual(sortedAssets[0].assetType, SessionAssetType(rawValue: SessionAssetType.liveStreamVideo.rawValue))
             XCTAssertGreaterThan(sortedAssets[0].year, 2016)
-            XCTAssertEqual(sortedAssets[0].sessionId, "201")
+            XCTAssertEqual(sortedAssets[0].sessionId, "wwdc2018-201")
             XCTAssertEqual(sortedAssets[0].remoteURL, "http://devstreaming.apple.com/videos/wwdc/2016/live/mission_ghub2yon5yewl2i/atv_mvp.m3u8")
         }
     }

--- a/Releases/appcast_v5.xml
+++ b/Releases/appcast_v5.xml
@@ -7,6 +7,16 @@
         <language>en</language>
 		
 		<item>
+            <title>Version 6.0.2</title>
+			<description><![CDATA[
+				<h3>This update fixes an important issue with live streaming, please update to be able to watch live sessions during the week.</h3>
+			]]></description>
+            <pubDate>Mon, 4 Jun 2018 22:00:00 -0300</pubDate>
+            <enclosure url="https://github.com/insidegui/WWDC/releases/download/6.0.2/WWDC_v6.0.2.zip" sparkle:version="812" sparkle:shortVersionString="6.0.2" length="16092321" type="application/octet-stream" />
+            <sparkle:minimumSystemVersion>10.12.2</sparkle:minimumSystemVersion>
+        </item>
+		
+		<item>
             <title>Version 6.0.1</title>
 			<description><![CDATA[
 				<h2>This version contains some bugfixes so you can have a great experience during this WWDC week.<br>

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -72,7 +72,7 @@ final class AppCoordinator {
 
         DownloadManager.shared.start(with: storage)
 
-        liveObserver = LiveObserver(dateProvider: today, storage: storage)
+        liveObserver = LiveObserver(dateProvider: today, storage: storage, syncEngine: syncEngine)
 
         // Primary UI Intialization
 
@@ -470,7 +470,6 @@ final class AppCoordinator {
 
         DispatchQueue.main.async {
             self.syncEngine.syncContent()
-            self.syncEngine.syncLiveVideos()
 
             self.liveObserver.refresh()
 

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Constants {
 
-    static let coreSchemaVersion: UInt64 = 43
+    static let coreSchemaVersion: UInt64 = 44
 
     static let thumbnailHeight: CGFloat = 150
 
@@ -23,10 +23,7 @@ struct Constants {
     static let liveSessionCheckInterval: TimeInterval = 10.0
 
     /// How many seconds to subtract from the start time of a live session to consider it live
-    static let liveSessionStartTimeTolerance: TimeInterval = 30
-
-    /// How many seconds to add to the end time of a live session before considering it finished
-    static let liveSessionEndTimeTolerance: TimeInterval = 60 * 15
+    static let liveSessionStartTimeTolerance: TimeInterval = 300
 
     /// Whether to enable the new "Featured" tab
     static let isFeaturedTabEnabled = false

--- a/WWDC/Info.plist
+++ b/WWDC/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.1</string>
+	<string>6.0.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>810</string>
+	<string>812</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/WWDC/LiveObserver.swift
+++ b/WWDC/LiveObserver.swift
@@ -102,11 +102,6 @@ final class LiveObserver {
         setLiveFlag(false, for: notLiveAnymore)
         setLiveFlag(true, for: liveInstances.toArray())
 
-        print("Not live anymore:")
-        print(notLiveAnymore)
-        print("Live instances:")
-        print(liveInstances)
-
         os_log("There are %{public}d live instances. %{public}d instances are not live anymore",
                log: log,
                type: .debug,

--- a/WWDC/LiveObserver.swift
+++ b/WWDC/LiveObserver.swift
@@ -17,6 +17,7 @@ final class LiveObserver {
     private let log = OSLog(subsystem: "WWDC", category: "LiveObserver")
     private let dateProvider: DateProvider
     private let storage: Storage
+    private let syncEngine: SyncEngine
 
     private lazy var backgroundActivity: NSBackgroundActivityScheduler = {
         let backgroundActivity = NSBackgroundActivityScheduler(identifier: "io.wwdc.liveobserver.backgroundactivity")
@@ -31,9 +32,10 @@ final class LiveObserver {
 
     private let specialEventsObserver: CloudKitLiveObserver
 
-    init(dateProvider: @escaping DateProvider, storage: Storage) {
+    init(dateProvider: @escaping DateProvider, storage: Storage, syncEngine: SyncEngine) {
         self.dateProvider = dateProvider
         self.storage = storage
+        self.syncEngine = syncEngine
         specialEventsObserver = CloudKitLiveObserver(storage: storage)
     }
 
@@ -78,13 +80,18 @@ final class LiveObserver {
     private func checkForLiveSessions() {
         os_log("checkForLiveSessions()", log: log, type: .debug)
 
-        let startTime = dateProvider()
-        let endTime = dateProvider().addingTimeInterval(Constants.liveSessionEndTimeTolerance)
+        syncEngine.syncLiveVideos { [weak self] in
+            self?.updateLiveFlags()
+        }
+    }
+
+    private func updateLiveFlags() {
+        let startTime = dateProvider().addingTimeInterval(-Constants.liveSessionStartTimeTolerance)
 
         let previouslyLiveInstances = allLiveInstances.toArray()
         var notLiveAnymore: [SessionInstance] = []
 
-        let liveInstances = storage.realm.objects(SessionInstance.self).filter("startTime <= %@ AND endTime > %@ AND SUBQUERY(session.assets, $asset, $asset.rawAssetType == %@).@count > 0", startTime, endTime, SessionAssetType.liveStreamVideo.rawValue)
+        let liveInstances = storage.realm.objects(SessionInstance.self).filter("startTime <= %@ AND SUBQUERY(session.assets, $asset, $asset.rawAssetType == %@ AND $asset.actualEndDate == nil).@count > 0", startTime, SessionAssetType.liveStreamVideo.rawValue)
 
         previouslyLiveInstances.forEach { instance in
             if !liveInstances.contains(instance) {
@@ -94,6 +101,17 @@ final class LiveObserver {
 
         setLiveFlag(false, for: notLiveAnymore)
         setLiveFlag(true, for: liveInstances.toArray())
+
+        print("Not live anymore:")
+        print(notLiveAnymore)
+        print("Live instances:")
+        print(liveInstances)
+
+        os_log("There are %{public}d live instances. %{public}d instances are not live anymore",
+               log: log,
+               type: .debug,
+               liveInstances.count,
+               notLiveAnymore.count)
     }
 
     private func setLiveFlag(_ value: Bool, for instances: [SessionInstance]) {


### PR DESCRIPTION
I was having to manually push sessions live via CloudKit because some changes in our database structure caused the live assets to not be associated correctly. I also modified the live observer so it always queries the Apple API for live videos and removes assets that have their `actualEndDate` set from live instead of relying on end time calculation.