### PR TITLE
More live streaming improvements

### DIFF
--- a/Releases/appcast_v5.xml
+++ b/Releases/appcast_v5.xml
@@ -7,6 +7,16 @@
         <language>en</language>
 		
 		<item>
+            <title>Version 6.0.3</title>
+			<description><![CDATA[
+				<p>Fixes live streaming reliability.</p>
+			]]></description>
+            <pubDate>Tue, 5 Jun 2018 15:20:00 -0300</pubDate>
+            <enclosure url="https://github.com/insidegui/WWDC/releases/download/6.0.3/WWDC_v6.0.3.zip" sparkle:version="813" sparkle:shortVersionString="6.0.3" length="16096201" type="application/octet-stream" />
+            <sparkle:minimumSystemVersion>10.12.2</sparkle:minimumSystemVersion>
+        </item>		
+		
+		<item>
             <title>Version 6.0.2</title>
 			<description><![CDATA[
 				<h3>This update fixes an important issue with live streaming, please update to be able to watch live sessions during the week.</h3>

--- a/Releases/appcast_v5.xml
+++ b/Releases/appcast_v5.xml
@@ -9,7 +9,7 @@
 		<item>
             <title>Version 6.0.3</title>
 			<description><![CDATA[
-				<p>Fixes live streaming reliability.</p>
+				<p>Improves live streaming reliability.</p>
 			]]></description>
             <pubDate>Tue, 5 Jun 2018 15:20:00 -0300</pubDate>
             <enclosure url="https://github.com/insidegui/WWDC/releases/download/6.0.3/WWDC_v6.0.3.zip" sparkle:version="813" sparkle:shortVersionString="6.0.3" length="16096201" type="application/octet-stream" />

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -20,7 +20,10 @@ struct Constants {
     static let watchedVideoRelativePosition: Double = 0.97
 
     /// How many seconds between each live session check
-    static let liveSessionCheckInterval: TimeInterval = 10.0
+    static let liveSessionCheckInterval: TimeInterval = 60.0
+
+    /// How many seconds of tolerance to give the live session check timer
+    static let liveSessionCheckTolerance: TimeInterval = 30.0
 
     /// How many MINUTES to subtract from the start time of a live session to consider it live
     static let liveSessionStartTimeTolerance: Int = 3

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -22,8 +22,8 @@ struct Constants {
     /// How many seconds between each live session check
     static let liveSessionCheckInterval: TimeInterval = 10.0
 
-    /// How many seconds to subtract from the start time of a live session to consider it live
-    static let liveSessionStartTimeTolerance: TimeInterval = 300
+    /// How many MINUTES to subtract from the start time of a live session to consider it live
+    static let liveSessionStartTimeTolerance: Int = -3
 
     /// Whether to enable the new "Featured" tab
     static let isFeaturedTabEnabled = false

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -23,7 +23,7 @@ struct Constants {
     static let liveSessionCheckInterval: TimeInterval = 10.0
 
     /// How many MINUTES to subtract from the start time of a live session to consider it live
-    static let liveSessionStartTimeTolerance: Int = -3
+    static let liveSessionStartTimeTolerance: Int = 3
 
     /// Whether to enable the new "Featured" tab
     static let isFeaturedTabEnabled = false

--- a/WWDC/Info.plist
+++ b/WWDC/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.0.2</string>
+	<string>6.0.3</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -36,7 +36,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>812</string>
+	<string>813</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
Using `Calendar` for time calculations, added some extra logging to improve debugging and hooked up Cmd+R refresh action to also refresh live sessions.