### PR TITLE
Fixes session lists to allow arbitrary navigation

### DIFF
--- a/ConfCore/SyncEngine.swift
+++ b/ConfCore/SyncEngine.swift
@@ -61,9 +61,9 @@ public final class SyncEngine {
                 self.storage.store(contentResult: scheduleResult) { error in
                     NotificationCenter.default.post(name: .SyncEngineDidSyncSessionsAndSchedule, object: error)
 
-//                    guard error == nil else { return }
+                    guard error == nil else { return }
 
-//                    self.syncFeaturedSections()
+                    self.syncFeaturedSections()
                 }
             }
         }

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3A6227031F9272A300D5F687 /* contents.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A6227021F9272A300D5F687 /* contents.json */; };
 		4D5EB0F820598E6000D4BC52 /* SessionRowProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */; };
 		4DEEC3A32051C8D400376595 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEEC3A22051C8D400376595 /* TestUtilities.swift */; };
+		4DF6641620C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6641520C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift */; };
 		DD0159A71ECFE26200F980F1 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A61ECFE26200F980F1 /* DeepLink.swift */; };
 		DD0159A91ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */; };
 		DD0159CF1ED0CD3A00F980F1 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159CE1ED0CD3A00F980F1 /* PreferencesWindowController.swift */; };
@@ -353,6 +354,7 @@
 		3A6227021F9272A300D5F687 /* contents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = contents.json; sourceTree = "<group>"; };
 		4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowProvider.swift; sourceTree = "<group>"; };
 		4DEEC3A22051C8D400376595 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
+		4DF6641520C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionsTableViewController+SupportingTypesAndExtensions.swift"; sourceTree = "<group>"; };
 		DD0159A61ECFE26200F980F1 /* DeepLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
 		DD0159A81ED09F5D00F980F1 /* AppCoordinator+Bookmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+Bookmarks.swift"; sourceTree = "<group>"; };
 		DD0159CE1ED0CD3A00F980F1 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
@@ -1046,6 +1048,7 @@
 			children = (
 				DD36A4B11E478C6A00B2EA88 /* SessionsSplitViewController.swift */,
 				DD7F38611EABD6CF002D8C00 /* SessionsTableViewController.swift */,
+				4DF6641520C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift */,
 				4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */,
 				DDEA85F81EB52AA6002AE0EB /* Playback */,
 				DDFA10C71EBFD897001DCF66 /* Detail */,
@@ -1912,6 +1915,7 @@
 				DDB352821EC7C55300254815 /* DateProvider.swift in Sources */,
 				DDC678221EDB956700A4E19C /* BookmarkViewController.swift in Sources */,
 				DD7F386A1EABE996002D8C00 /* SessionTableCellView.swift in Sources */,
+				4DF6641620C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift in Sources */,
 				DD4DED6B1ED6605D00624EAF /* LoggingHelper.swift in Sources */,
 				DD36A4B21E478C6A00B2EA88 /* SessionsSplitViewController.swift in Sources */,
 				DDB352841EC7C74C00254815 /* LiveObserver.swift in Sources */,

--- a/WWDC/AppCoordinator+Shelf.swift
+++ b/WWDC/AppCoordinator+Shelf.swift
@@ -55,7 +55,7 @@ extension AppCoordinator: ShelfViewControllerDelegate {
 
         if isReturningFromPip {
             tabController.activeTab = tab
-            currentListController?.selectSession(with: identifier)
+            currentListController?.select(session: SessionIdentifier(identifier))
             currentPlayerController?.view.isHidden = false
         }
 

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -268,16 +268,10 @@ final class AppCoordinator {
                 self.tabController.hideLoading()
                 self.searchCoordinator.configureFilters()
 
-                // Currently these two things must happen together and in this order for
-                // new information to be displayed. It's not ideal
                 self.videosController.listViewController.sessionRowProvider = VideosSessionRowProvider(tracks: tracks)
-                self.searchCoordinator.applyVideosFilters()
 
-                // Currently these two things must happen together and in this order for
-                // new information to be displayed. It's not ideal
                 self.scheduleController.listViewController.sessionRowProvider = ScheduleSessionRowProvider(scheduleSections: sections)
                 self.scrollToTodayIfWWDC()
-                self.searchCoordinator.applyScheduleFilters()
             }).disposed(by: disposeBag)
 
         liveObserver.start()
@@ -364,12 +358,8 @@ final class AppCoordinator {
 
     private func saveApplicationState() {
         Preferences.shared.activeTab = activeTab
-        if let identifier = selectedScheduleItemValue?.identifier {
-            Preferences.shared.selectedScheduleItemIdentifier = identifier
-        }
-        if let identifier = selectedSessionValue?.identifier {
-            Preferences.shared.selectedVideoItemIdentifier = identifier
-        }
+        Preferences.shared.selectedScheduleItemIdentifier = selectedScheduleItemValue?.identifier
+        Preferences.shared.selectedVideoItemIdentifier = selectedSessionValue?.identifier
         Preferences.shared.filtersState = searchCoordinator.currentFiltersState()
     }
 

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -83,10 +83,7 @@ final class AppCoordinator {
         featuredController.identifier = NSUserInterfaceItemIdentifier(rawValue: "Featured")
         let featuredItem = NSTabViewItem(viewController: featuredController)
         featuredItem.label = "Featured"
-
-        if Constants.isFeaturedTabEnabled {
-            tabController.addTabViewItem(featuredItem)
-        }
+        tabController.addTabViewItem(featuredItem)
 
         // Schedule
         scheduleController = SessionsSplitViewController(windowController: windowController, listStyle: .schedule)
@@ -182,11 +179,9 @@ final class AppCoordinator {
             self?.updateSelectedViewModelRegardlessOfTab()
         }).disposed(by: disposeBag)
 
-        if Constants.isFeaturedTabEnabled {
-            storage.featuredSectionsObservable.subscribeOn(MainScheduler.instance).subscribe(onNext: { [weak self] sections in
-                self?.featuredController.sections = sections.map { FeaturedSectionViewModel(section: $0) }
-            }).disposed(by: disposeBag)
-        }
+        storage.featuredSectionsObservable.subscribeOn(MainScheduler.instance).subscribe(onNext: { [weak self] sections in
+            self?.featuredController.sections = sections.map { FeaturedSectionViewModel(section: $0) }
+        }).disposed(by: disposeBag)
     }
 
     private func updateSelectedViewModelRegardlessOfTab() {

--- a/WWDC/AppDelegate.swift
+++ b/WWDC/AppDelegate.swift
@@ -70,13 +70,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillBecomeActive(_ notification: Notification) {
 
-        if coordinator.windowController.window?.isVisible == false {
+        // Switches to app via application switcher
+        if !NSApp.windows.contains(where: { $0.isVisible }) {
             coordinator.windowController.showWindow(self)
         }
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
 
+        // User clicks dock item, double clicks app in finder, etc
         if !flag {
             coordinator.windowController.showWindow(sender)
 

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -28,7 +28,4 @@ struct Constants {
     /// How many MINUTES to subtract from the start time of a live session to consider it live
     static let liveSessionStartTimeTolerance: Int = 3
 
-    /// Whether to enable the new "Featured" tab
-    static let isFeaturedTabEnabled = true
-
 }

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -29,6 +29,6 @@ struct Constants {
     static let liveSessionStartTimeTolerance: Int = 3
 
     /// Whether to enable the new "Featured" tab
-    static let isFeaturedTabEnabled = false
+    static let isFeaturedTabEnabled = true
 
 }

--- a/WWDC/FilterType.swift
+++ b/WWDC/FilterType.swift
@@ -16,6 +16,7 @@ protocol FilterType {
     var identifier: String { get set }
     var isEmpty: Bool { get }
     var predicate: NSPredicate? { get }
+    mutating func reset()
     func dictionaryRepresentation() -> WWDCFilterTypeDictionary
 
 }

--- a/WWDC/MainWindowController.swift
+++ b/WWDC/MainWindowController.swift
@@ -10,7 +10,7 @@ import Cocoa
 import PlayerUI
 
 enum MainWindowTab: Int {
-//    case featured
+    case featured
     case schedule
     case videos
 

--- a/WWDC/MultipleChoiceFilter.swift
+++ b/WWDC/MultipleChoiceFilter.swift
@@ -130,6 +130,10 @@ struct MultipleChoiceFilter: FilterType {
         self.selectedOptions = selectedOptions
     }
 
+    mutating func reset() {
+        selectedOptions = []
+    }
+
     func dictionaryRepresentation() -> WWDCFilterTypeDictionary {
         var dictionary: WWDCFilterTypeDictionary = WWDCFilterTypeDictionary()
 

--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -185,13 +185,8 @@ final class SearchCoordinator {
         // set delegates
         scheduleSearchController.delegate = self
         videosSearchController.delegate = self
-    }
 
-    func applyScheduleFilters() {
         updateSearchResults(for: scheduleController, with: scheduleSearchController.filters)
-    }
-
-    func applyVideosFilters() {
         updateSearchResults(for: videosController, with: videosSearchController.filters)
     }
 
@@ -224,7 +219,7 @@ final class SearchCoordinator {
     }
 
     fileprivate func updateSearchResults(for controller: SessionsTableViewController, with filters: [FilterType]) {
-        controller.filterResults = newFilterResults(for: controller, filters: filters)
+        controller.setFilterResults(newFilterResults(for: controller, filters: filters), animated: true, selecting: nil)
     }
 
     @objc fileprivate func activateSearchField() {

--- a/WWDC/SearchFiltersViewController.swift
+++ b/WWDC/SearchFiltersViewController.swift
@@ -73,6 +73,16 @@ final class SearchFiltersViewController: NSViewController {
 
     private var effectiveFilters: [FilterType] = []
 
+    func resetFilters() {
+
+        filters = filters.map {
+            var resetFilter = $0
+            resetFilter.reset()
+
+            return resetFilter
+        }
+    }
+
     weak var delegate: SearchFiltersViewControllerDelegate?
 
     @IBAction func eventsPopUpAction(_ sender: Any) {
@@ -209,6 +219,7 @@ final class SearchFiltersViewController: NSViewController {
         }
     }
 
+    /// Updates the UI to match the active filters
     private func updateUI() {
         guard isViewLoaded else { return }
 

--- a/WWDC/SessionRow.swift
+++ b/WWDC/SessionRow.swift
@@ -41,6 +41,16 @@ final class SessionRow: CustomDebugStringConvertible {
     }
 }
 
+extension SessionRow {
+
+    func represents(session: SessionIdentifiable) -> Bool {
+        if case .session(let viewModel) = kind {
+            return viewModel.identifier == session.sessionIdentifier
+        }
+        return false
+    }
+}
+
 extension SessionRow: Equatable {
 
     var hashValue: Int {

--- a/WWDC/SessionRowProvider.swift
+++ b/WWDC/SessionRowProvider.swift
@@ -10,7 +10,7 @@ import ConfCore
 import RealmSwift
 
 protocol SessionRowProvider {
-    func sessionRowIdentifierForToday() -> String?
+    func sessionRowIdentifierForToday() -> SessionIdentifiable?
     func sessionRows() -> [SessionRow]
 
     var sessionSortingFunction: (Session, Session) -> Bool { get }
@@ -41,7 +41,7 @@ struct VideosSessionRowProvider: SessionRowProvider {
         return rows
     }
 
-    func sessionRowIdentifierForToday() -> String? {
+    func sessionRowIdentifierForToday() -> SessionIdentifiable? {
         return nil
     }
 }
@@ -78,12 +78,12 @@ struct ScheduleSessionRowProvider: SessionRowProvider {
         return rows
     }
 
-    func sessionRowIdentifierForToday() -> String? {
+    func sessionRowIdentifierForToday() -> SessionIdentifiable? {
 
         guard let section = scheduleSections.filter("representedDate >= %@", today()).first else { return nil }
 
         guard let identifier = section.instances.first?.session?.identifier else { return nil }
 
-        return identifier
+        return SessionIdentifier(identifier)
     }
 }

--- a/WWDC/SessionsSplitViewController.swift
+++ b/WWDC/SessionsSplitViewController.swift
@@ -17,9 +17,9 @@ final class SessionsSplitViewController: NSSplitViewController {
 
     var listViewController: SessionsTableViewController
     var detailViewController: SessionDetailsViewController
-    var isResizingSplitView: Bool = false
+    var isResizingSplitView = false
     var windowController: MainWindowController
-    var setupDone: Bool = false
+    var setupDone = false
 
     init(windowController: MainWindowController, listStyle: SessionsListStyle) {
         self.windowController = windowController

--- a/WWDC/SessionsTableViewController+SupportingTypesAndExtensions.swift
+++ b/WWDC/SessionsTableViewController+SupportingTypesAndExtensions.swift
@@ -1,0 +1,140 @@
+//
+//  SessionsTableViewController+SupportingTypesAndExtensions.swift
+//  WWDC
+//
+//  Created by Allen Humphreys on 6/6/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import ConfCore
+import RealmSwift
+import os.log
+
+/// Conforming to this protocol means the type is capable
+/// of uniquely identifying a `Session`
+///
+/// TODO: Move to ConfCore and make it "official"?
+protocol SessionIdentifiable {
+    var sessionIdentifier: String { get }
+}
+
+struct SessionIdentifier: SessionIdentifiable {
+    let sessionIdentifier: String
+
+    init(_ string: String) {
+        sessionIdentifier = string
+    }
+}
+
+extension SessionViewModel: SessionIdentifiable {
+    var sessionIdentifier: String {
+        return identifier
+    }
+}
+
+protocol SessionsTableViewControllerDelegate: class {
+
+    func sessionTableViewContextMenuActionWatch(viewModels: [SessionViewModel])
+    func sessionTableViewContextMenuActionUnWatch(viewModels: [SessionViewModel])
+    func sessionTableViewContextMenuActionFavorite(viewModels: [SessionViewModel])
+    func sessionTableViewContextMenuActionRemoveFavorite(viewModels: [SessionViewModel])
+    func sessionTableViewContextMenuActionDownload(viewModels: [SessionViewModel])
+    func sessionTableViewContextMenuActionCancelDownload(viewModels: [SessionViewModel])
+    func sessionTableViewContextMenuActionRevealInFinder(viewModels: [SessionViewModel])
+}
+
+extension Session {
+
+    var isWatched: Bool {
+        if let progress = progresses.first {
+            return progress.relativePosition > Constants.watchedVideoRelativePosition
+        }
+
+        return false
+    }
+}
+
+extension Array where Element == SessionRow {
+
+    func index(of session: SessionIdentifiable) -> Int? {
+        return index { row in
+            guard case .session(let viewModel) = row.kind else { return false }
+
+            return viewModel.identifier == session.sessionIdentifier
+        }
+    }
+
+    func firstSessionRowIndex() -> Int? {
+        return index { row in
+            if case .session = row.kind {
+                return true
+            }
+            return false
+        }
+    }
+
+    func forEachSessionViewModel(_ body: (SessionViewModel) throws -> Void) rethrows {
+        try forEach {
+            if case .session(let viewModel) = $0.kind {
+                try body(viewModel)
+            }
+        }
+    }
+}
+
+struct FilterResults {
+
+    static var empty: FilterResults {
+        return FilterResults(storage: nil, query: nil)
+    }
+
+    /// This becomes an OperationQueue for aborting, tada
+    private static let searchQueue = DispatchQueue(label: "Search", qos: .userInteractive)
+
+    var query: NSPredicate? {
+        didSet {
+            searchResults = nil
+        }
+    }
+
+    let storage: Storage?
+
+    private var searchResults: Results<Session>?
+
+    init(storage: Storage?, query: NSPredicate?) {
+        self.storage = storage
+        self.query = query
+    }
+
+    func results(with closure: @escaping (Results<Session>?) -> Void) {
+
+        if let searchResults = searchResults {
+            closure(searchResults)
+            return
+        }
+
+        guard let query = query, let storage = storage else {
+            closure(nil)
+            return
+        }
+
+        // I'm pretty sure doing this on the background isn't saving any time
+        FilterResults.searchQueue.async {
+            do {
+                let realm = try Realm(configuration: storage.realmConfig)
+
+                let objects = realm.objects(Session.self).filter(query)
+                let reference = ThreadSafeReference(to: objects)
+                DispatchQueue.main.async {
+                    closure(storage.realm.resolve(reference))
+                }
+            } catch {
+                os_log("Failed to initialize Realm for searching: %{public}@",
+                       log: .default,
+                       type: .error,
+                       String(describing: error))
+                LoggingHelper.registerError(error, info: ["when": "Searching"])
+            }
+        }
+    }
+}

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -95,9 +95,7 @@ class SessionsTableViewController: NSViewController {
     private func selectSessionImmediately(with identifier: SessionIdentifiable) {
 
         guard let index = displayedRows.index(where: { row in
-            guard case .session(let viewModel) = row.kind else { return false }
-
-            return viewModel.identifier == identifier.sessionIdentifier
+            row.represents(session: identifier)
         }) else {
             return
         }
@@ -169,7 +167,7 @@ class SessionsTableViewController: NSViewController {
             guard let viewModel = SessionViewModel(session: session) else { return nil }
 
             for row in allRows {
-                if case .session(let sessionViewModel) = row.kind, sessionViewModel.session.identifier == session.identifier {
+                if row.represents(session: SessionIdentifier(session.identifier)) {
                     return row
                 }
             }
@@ -209,6 +207,7 @@ class SessionsTableViewController: NSViewController {
             !isSessionVisible(for: initialSelection) && canDisplay(session: initialSelection) {
 
             searchController.resetFilters()
+            _filterResults = .empty
             displayedRows = allRows
         }
 
@@ -335,19 +334,13 @@ class SessionsTableViewController: NSViewController {
         assert(hasPerformedInitialRowDisplay, "Rows must be displayed before checking this value")
 
         return displayedRows.contains { row -> Bool in
-            if case .session(let viewModel) = row.kind {
-                return viewModel.identifier == session.sessionIdentifier
-            }
-            return false
+            row.represents(session: session)
         }
     }
 
     func canDisplay(session: SessionIdentifiable) -> Bool {
         return allRows.contains { row -> Bool in
-            if case .session(let viewModel) = row.kind {
-                return viewModel.identifier == session.sessionIdentifier
-            }
-            return false
+            row.represents(session: session)
         }
     }
 

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -11,24 +11,11 @@ import RxSwift
 import RxCocoa
 import RealmSwift
 import ConfCore
+import os.log
 
-protocol SessionsTableViewControllerDelegate: class {
-
-    func sessionTableViewContextMenuActionWatch(viewModels: [SessionViewModel])
-    func sessionTableViewContextMenuActionUnWatch(viewModels: [SessionViewModel])
-    func sessionTableViewContextMenuActionFavorite(viewModels: [SessionViewModel])
-    func sessionTableViewContextMenuActionRemoveFavorite(viewModels: [SessionViewModel])
-    func sessionTableViewContextMenuActionDownload(viewModels: [SessionViewModel])
-    func sessionTableViewContextMenuActionCancelDownload(viewModels: [SessionViewModel])
-    func sessionTableViewContextMenuActionRevealInFinder(viewModels: [SessionViewModel])
-}
+// MARK: - Sessions Table View Controller
 
 class SessionsTableViewController: NSViewController {
-
-    fileprivate struct Metrics {
-        static let headerRowHeight: CGFloat = 20
-        static let sessionRowHeight: CGFloat = 64
-    }
 
     private let disposeBag = DisposeBag()
 
@@ -37,159 +24,6 @@ class SessionsTableViewController: NSViewController {
     var selectedSession = Variable<SessionViewModel?>(nil)
 
     let style: SessionsListStyle
-
-    var searchResults: Results<Session>? {
-        didSet {
-            updateWithSearchResults()
-        }
-    }
-
-    var sessionRowProvider: SessionRowProvider? {
-        didSet {
-            updateAllSessionRows()
-        }
-    }
-
-    private var allRows: [SessionRow] = []
-
-    private(set) var displayedRows: [SessionRow] = []
-
-    // MARK: - Displaying Rows
-
-    lazy var displayedRowsLock: DispatchQueue = {
-
-        return DispatchQueue(label: "io.wwdc.sessiontable.displayedrows.lock\(self.hashValue)", qos: .userInteractive)
-    }()
-
-    private var hasPerformedInitialRowDisplay = false
-
-    private func performInitialRowDisplayIfNeeded(displaying rows: [SessionRow]) -> Bool {
-
-        guard !hasPerformedInitialRowDisplay else { return true }
-        hasPerformedInitialRowDisplay = true
-
-        displayedRowsLock.suspend()
-
-        displayedRows = rows
-
-        NSAnimationContext.runAnimationGroup({ (context) in
-            context.duration = 0
-            tableView.reloadData()
-        }, completionHandler: {
-
-            if let deferredSelection = self.deferredSelection {
-                self.deferredSelection = nil
-                self.selectSession(with: deferredSelection.identifier, scrollOnly: deferredSelection.scrollOnly)
-            }
-
-            // Ensures an initial selection since `scrollOnly` won't select anything
-            if self.tableView.selectedRow == -1,
-                let defaultIndex = rows.firstSessionRowIndex() {
-
-                self.tableView.selectRowIndexes(IndexSet(integer: defaultIndex), byExtendingSelection: false)
-            }
-
-            self.scrollView.animator().alphaValue = 1
-            self.tableView.allowsEmptySelection = false
-            self.displayedRowsLock.resume()
-        })
-
-        return false
-    }
-
-    func setDisplayedRows(_ newValue: [SessionRow], animated: Bool) {
-
-        // To support weekday in the context row of the session cell only when filters are active
-        let showWeekday = !(searchResults?.isEmpty ?? true)
-        for row in newValue {
-            if case .session(let viewModel) = row.kind {
-                viewModel.showsWeekdayInContext = showWeekday
-            }
-        }
-
-        guard performInitialRowDisplayIfNeeded(displaying: newValue) else { return }
-
-        // Dismiss the menu when the displayed rows are about to change otherwise it will crash
-        tableView.menu?.cancelTrackingWithoutAnimation()
-
-        displayedRowsLock.async {
-
-            let oldValue = self.displayedRows
-
-            // Same elements, same order: https://github.com/apple/swift/blob/master/stdlib/public/core/Arrays.swift.gyb#L2203
-            if oldValue == newValue { return }
-
-            let oldRowsSet = Set(oldValue.enumerated().map { IndexedSessionRow(sessionRow: $1, index: $0) })
-            let newRowsSet = Set(newValue.enumerated().map { IndexedSessionRow(sessionRow: $1, index: $0) })
-
-            let removed = oldRowsSet.subtracting(newRowsSet)
-            let added = newRowsSet.subtracting(oldRowsSet)
-
-            let removedIndexes = IndexSet(removed.map { $0.index })
-            let addedIndexes = IndexSet(added.map { $0.index })
-
-            // Only reload rows if their relative positioning changes. This prevents
-            // cell contents from flashing when cells are unnecessarily reloaded
-            var needReloadedIndexes = IndexSet()
-
-            let sortedOldRows = oldRowsSet.intersection(newRowsSet).sorted(by: { (row1, row2) -> Bool in
-                return row1.index < row2.index
-            })
-
-            let sortedNewRows = newRowsSet.intersection(oldRowsSet).sorted(by: { (row1, row2) -> Bool in
-                return row1.index < row2.index
-            })
-
-            for (oldSessionRowIndex, newSessionRowIndex) in zip(sortedOldRows, sortedNewRows) where oldSessionRowIndex.sessionRow != newSessionRowIndex.sessionRow {
-                needReloadedIndexes.insert(newSessionRowIndex.index)
-            }
-
-            DispatchQueue.main.sync {
-
-                // Preserve selected rows
-                let selectedRows = self.tableView.selectedRowIndexes.compactMap { (index) -> IndexedSessionRow? in
-                    guard index < oldValue.endIndex else { return nil }
-                    return IndexedSessionRow(sessionRow: oldValue[index], index: index)
-                }
-
-                var selectedIndexes = IndexSet(newRowsSet.intersection(selectedRows).map { $0.index })
-                if selectedIndexes.isEmpty, let defaultIndex = newValue.firstSessionRowIndex() {
-                    selectedIndexes.insert(defaultIndex)
-                }
-
-                NSAnimationContext.beginGrouping()
-                let context = NSAnimationContext.current
-                if !animated {
-                    context.duration = 0
-                }
-
-                context.completionHandler = {
-                    NSAnimationContext.runAnimationGroup({ (context) in
-                        context.allowsImplicitAnimation = true
-                        self.tableView.scrollRowToCenter(selectedIndexes.first ?? 0)
-                    }, completionHandler: nil)
-                }
-
-                self.tableView.beginUpdates()
-
-                self.tableView.removeRows(at: removedIndexes, withAnimation: [NSTableView.AnimationOptions.slideLeft])
-
-                self.tableView.insertRows(at: addedIndexes, withAnimation: [NSTableView.AnimationOptions.slideDown])
-
-                // insertRows(::) and removeRows(::) will query the delegate for the row count at the beginning
-                // so we delay updating the data model until after those methods have done their thing
-                self.displayedRows = newValue
-
-                // This must be after you update the backing model
-                self.tableView.reloadData(forRowIndexes: needReloadedIndexes, columnIndexes: IndexSet(integersIn: 0..<1))
-
-                self.tableView.selectRowIndexes(selectedIndexes, byExtendingSelection: false)
-
-                self.tableView.endUpdates()
-                NSAnimationContext.endGrouping()
-            }
-        }
-    }
 
     init(style: SessionsListStyle) {
         self.style = style
@@ -202,135 +36,6 @@ class SessionsTableViewController: NSViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    private var deferredSelection: (identifier: String, scrollOnly: Bool)?
-
-    func selectSession(with identifier: String, scrollOnly: Bool = false, deferIfNeeded: Bool = false) {
-
-        // If we haven't yet displayed our rows, likely because we haven't come on screen
-        // yet. We defer scrolling to the requested identifier until that time.
-        guard hasPerformedInitialRowDisplay || !deferIfNeeded else {
-            deferredSelection = (identifier, scrollOnly)
-            return
-        }
-        guard let index = displayedRows.index(where: { row in
-            guard case .session(let viewModel) = row.kind else { return false }
-
-            return viewModel.identifier == identifier
-        }) else {
-            return
-        }
-
-        tableView.scrollRowToCenter(index)
-
-        if !scrollOnly {
-            tableView.selectRowIndexes(IndexSet([index]), byExtendingSelection: false)
-        }
-    }
-
-    func scrollToToday() {
-        if let identifier = sessionRowProvider?.sessionRowIdentifierForToday() {
-            // We are skipping restoring the selection, but also we are only doing the scroll
-            // to today. This is currently resulting in the top of the list being selected but
-            // the list being scrolled to an event that is "today". I feel like we could either restore
-            // the saved selection and scroll to today OR scroll to and select the first session of "today"
-            selectSession(with: identifier, scrollOnly: true, deferIfNeeded: true)
-        }
-    }
-
-    override func viewDidAppear() {
-        super.viewDidAppear()
-
-        view.window?.makeFirstResponder(tableView)
-
-        performFirstUpdateIfNeeded()
-    }
-
-    /// This function is meant to ensure the table view gets populated
-    /// even if its data model gets added while it is offscreen. Specifically,
-    /// when this table view is not the initial active tab.
-    private func performFirstUpdateIfNeeded() {
-        guard !hasPerformedInitialRowDisplay else { return }
-
-        updateWithSearchResults()
-    }
-
-    private func updateAllSessionRows() {
-        allRows = sessionRowProvider?.sessionRows() ?? []
-    }
-
-    private func updateWithSearchResults() {
-        guard view.window != nil else { return }
-
-        guard let results = searchResults else {
-
-            if !allRows.isEmpty {
-                setDisplayedRows(allRows, animated: true)
-            }
-
-            return
-        }
-
-        guard let sessionRowProvider = sessionRowProvider else { return }
-
-        let sortingFunction = sessionRowProvider.sessionSortingFunction
-
-        let sessionRows: [SessionRow] = results.sorted(by: sortingFunction).compactMap { session in
-            guard let viewModel = SessionViewModel(session: session) else { return nil }
-
-            for row in allRows {
-                if case .session(let sessionViewModel) = row.kind, sessionViewModel.session.identifier == session.identifier {
-                    return row
-                }
-            }
-
-            return SessionRow(viewModel: viewModel)
-        }
-
-        setDisplayedRows(sessionRows, animated: true)
-    }
-
-    lazy var searchController: SearchFiltersViewController = {
-        return SearchFiltersViewController.loadFromStoryboard()
-    }()
-
-    lazy var tableView: WWDCTableView = {
-        let v = WWDCTableView()
-
-        // We control the intial selection during initialization
-        v.allowsEmptySelection = true
-
-        v.wantsLayer = true
-        v.focusRingType = .none
-        v.allowsMultipleSelection = true
-        v.backgroundColor = .listBackground
-        v.headerView = nil
-        v.rowHeight = Metrics.sessionRowHeight
-        v.autoresizingMask = [.width, .height]
-        v.floatsGroupRows = true
-        v.gridStyleMask = .solidHorizontalGridLineMask
-        v.gridColor = .darkGridColor
-
-        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "session"))
-        v.addTableColumn(column)
-
-        return v
-    }()
-
-    lazy var scrollView: NSScrollView = {
-        let v = NSScrollView()
-
-        v.focusRingType = .none
-        v.backgroundColor = .listBackground
-        v.borderType = .noBorder
-        v.documentView = self.tableView
-        v.hasVerticalScroller = true
-        v.hasHorizontalScroller = false
-        v.translatesAutoresizingMaskIntoConstraints = false
-        v.alphaValue = 0
-
-        return v
-    }()
 
     override func loadView() {
         view = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: MainWindowController.defaultRect.height))
@@ -372,8 +77,325 @@ class SessionsTableViewController: NSViewController {
             guard case .session(let viewModel) = self.displayedRows[index].kind else { return nil }
 
             return viewModel
-            }.bind(to: selectedSession).disposed(by: disposeBag)
+        }.bind(to: selectedSession).disposed(by: disposeBag)
     }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+
+        view.window?.makeFirstResponder(tableView)
+
+        performFirstUpdateIfNeeded()
+    }
+
+    // MARK: - Selection
+
+    private var initialSelection: SessionIdentifiable?
+
+    private func selectSessionImmediately(with identifier: SessionIdentifiable) {
+
+        guard let index = displayedRows.index(where: { row in
+            guard case .session(let viewModel) = row.kind else { return false }
+
+            return viewModel.identifier == identifier.sessionIdentifier
+        }) else {
+            return
+        }
+
+        tableView.scrollRowToCenter(index)
+        tableView.selectRowIndexes(IndexSet([index]), byExtendingSelection: false)
+    }
+
+    func select(session: SessionIdentifiable) {
+
+        let needsToClearSearchToAllowSelection = !isSessionVisible(for: session) && canDisplay(session: session)
+
+        // If we haven't yet displayed our rows, likely because we haven't come on screen
+        // yet. We defer scrolling to the requested identifier until that time.
+        guard hasPerformedInitialRowDisplay else {
+            searchController.resetFilters()
+            filterResults = .empty
+            initialSelection = session
+            return
+        }
+
+        if needsToClearSearchToAllowSelection {
+            searchController.resetFilters()
+            filterResults = .empty
+            updateWith(searchResults: nil, animated: view.window != nil, selecting: session)
+        } else {
+            selectSessionImmediately(with: session)
+        }
+    }
+
+    func scrollToToday() {
+
+        sessionRowProvider?.sessionRowIdentifierForToday().flatMap { select(session: $0) }
+    }
+
+    var hasPerformedFirstUpdate = false
+
+    /// This function is meant to ensure the table view gets populated
+    /// even if its data model gets added while it is offscreen. Specifically,
+    /// when this table view is not the initial active tab.
+    private func performFirstUpdateIfNeeded() {
+        guard !hasPerformedFirstUpdate else { return }
+        hasPerformedFirstUpdate = true
+
+        filterResults.results { [weak self] in
+            self?.updateWith(searchResults: $0, animated: true, selecting: nil)
+        }
+    }
+
+    private func updateWith(searchResults: Results<Session>?, animated: Bool, selecting session: SessionIdentifiable?) {
+        guard hasPerformedFirstUpdate else { return }
+
+        let showWeekday = !(searchResults?.isEmpty ?? true)
+        allRows.forEachSessionViewModel {
+            $0.showsWeekdayInContext = showWeekday
+        }
+
+        guard let results = searchResults else {
+
+            if !allRows.isEmpty {
+                setDisplayedRows(allRows, animated: animated, overridingSelectionWith: session)
+            }
+
+            return
+        }
+
+        guard let sessionRowProvider = sessionRowProvider else { return }
+
+        let sortingFunction = sessionRowProvider.sessionSortingFunction
+
+        let sessionRows: [SessionRow] = results.sorted(by: sortingFunction).compactMap { session in
+            guard let viewModel = SessionViewModel(session: session) else { return nil }
+
+            for row in allRows {
+                if case .session(let sessionViewModel) = row.kind, sessionViewModel.session.identifier == session.identifier {
+                    return row
+                }
+            }
+
+            return SessionRow(viewModel: viewModel)
+        }
+
+        setDisplayedRows(sessionRows, animated: animated, overridingSelectionWith: session)
+    }
+
+    // MARK: - Updating the Displayed Rows
+
+    var sessionRowProvider: SessionRowProvider? {
+        didSet {
+            allRows = sessionRowProvider?.sessionRows() ?? []
+        }
+    }
+
+    private var allRows: [SessionRow] = []
+
+    private(set) var displayedRows: [SessionRow] = []
+
+    lazy var displayedRowsLock = DispatchQueue(label: "io.wwdc.sessiontable.displayedrows.lock\(self.hashValue)", qos: .userInteractive)
+
+    private var hasPerformedInitialRowDisplay = false
+
+    private func performInitialRowDisplayIfNeeded(displaying rows: [SessionRow]) -> Bool {
+
+        guard !hasPerformedInitialRowDisplay else { return true }
+        hasPerformedInitialRowDisplay = true
+
+        displayedRowsLock.suspend()
+
+        displayedRows = rows
+
+        NSAnimationContext.runAnimationGroup({ (context) in
+            context.duration = 0
+            tableView.reloadData()
+        }, completionHandler: {
+
+            if let deferredSelection = self.initialSelection {
+                self.initialSelection = nil
+                self.selectSessionImmediately(with: deferredSelection)
+            }
+
+            // Ensure an initial selection
+            if self.tableView.selectedRow == -1,
+                let defaultIndex = rows.firstSessionRowIndex() {
+
+                self.tableView.selectRowIndexes(IndexSet(integer: defaultIndex), byExtendingSelection: false)
+            }
+
+            self.scrollView.animator().alphaValue = 1
+            self.tableView.allowsEmptySelection = false
+            self.displayedRowsLock.resume()
+        })
+
+        return false
+    }
+
+    func setDisplayedRows(_ newValue: [SessionRow], animated: Bool, overridingSelectionWith session: SessionIdentifiable?) {
+
+        guard performInitialRowDisplayIfNeeded(displaying: newValue) else { return }
+
+        // Dismiss the menu when the displayed rows are about to change otherwise it will crash
+        tableView.menu?.cancelTrackingWithoutAnimation()
+
+        displayedRowsLock.async {
+
+            let oldValue = self.displayedRows
+
+            // Same elements, same order: https://github.com/apple/swift/blob/master/stdlib/public/core/Arrays.swift.gyb#L2203
+            if oldValue == newValue { return }
+
+            let oldRowsSet = Set(oldValue.enumerated().map { IndexedSessionRow(sessionRow: $1, index: $0) })
+            let newRowsSet = Set(newValue.enumerated().map { IndexedSessionRow(sessionRow: $1, index: $0) })
+
+            let removed = oldRowsSet.subtracting(newRowsSet)
+            let added = newRowsSet.subtracting(oldRowsSet)
+
+            let removedIndexes = IndexSet(removed.map { $0.index })
+            let addedIndexes = IndexSet(added.map { $0.index })
+
+            // Only reload rows if their relative positioning changes. This prevents
+            // cell contents from flashing when cells are unnecessarily reloaded
+            var needReloadedIndexes = IndexSet()
+
+            let sortedOldRows = oldRowsSet.intersection(newRowsSet).sorted(by: { (row1, row2) -> Bool in
+                return row1.index < row2.index
+            })
+
+            let sortedNewRows = newRowsSet.intersection(oldRowsSet).sorted(by: { (row1, row2) -> Bool in
+                return row1.index < row2.index
+            })
+
+            for (oldSessionRowIndex, newSessionRowIndex) in zip(sortedOldRows, sortedNewRows) where oldSessionRowIndex.sessionRow != newSessionRowIndex.sessionRow {
+                needReloadedIndexes.insert(newSessionRowIndex.index)
+            }
+
+            DispatchQueue.main.sync {
+
+                var selectedIndexes = IndexSet()
+                if let session = session,
+                    let overrideIndex = newValue.index(of: session) {
+
+                    selectedIndexes.insert(overrideIndex)
+                } else {
+                    // Preserve selected rows if possible
+                    let selectedRows = self.tableView.selectedRowIndexes.compactMap { (index) -> IndexedSessionRow? in
+                        guard index < oldValue.endIndex else { return nil }
+                        return IndexedSessionRow(sessionRow: oldValue[index], index: index)
+                    }
+
+                    selectedIndexes = IndexSet(newRowsSet.intersection(selectedRows).map { $0.index })
+                }
+
+                if selectedIndexes.isEmpty, let defaultIndex = newValue.firstSessionRowIndex() {
+                    selectedIndexes.insert(defaultIndex)
+                }
+
+                NSAnimationContext.beginGrouping()
+                let context = NSAnimationContext.current
+                if !animated {
+                    context.duration = 0
+                }
+
+                context.completionHandler = {
+                    NSAnimationContext.runAnimationGroup({ (context) in
+                        context.allowsImplicitAnimation = animated
+                        self.tableView.scrollRowToCenter(selectedIndexes.first ?? 0)
+                    }, completionHandler: nil)
+                }
+
+                self.tableView.beginUpdates()
+
+                self.tableView.removeRows(at: removedIndexes, withAnimation: [NSTableView.AnimationOptions.slideLeft])
+
+                self.tableView.insertRows(at: addedIndexes, withAnimation: [NSTableView.AnimationOptions.slideDown])
+
+                // insertRows(::) and removeRows(::) will query the delegate for the row count at the beginning
+                // so we delay updating the data model until after those methods have done their thing
+                self.displayedRows = newValue
+
+                // This must be after you update the backing model
+                self.tableView.reloadData(forRowIndexes: needReloadedIndexes, columnIndexes: IndexSet(integersIn: 0..<1))
+
+                self.tableView.selectRowIndexes(selectedIndexes, byExtendingSelection: false)
+
+                self.tableView.endUpdates()
+                NSAnimationContext.endGrouping()
+            }
+        }
+    }
+
+    func isSessionVisible(for session: SessionIdentifiable) -> Bool {
+        return displayedRows.contains { row -> Bool in
+            if case .session(let viewModel) = row.kind {
+                return viewModel.identifier == session.sessionIdentifier
+            }
+            return false
+        }
+    }
+
+    func canDisplay(session: SessionIdentifiable) -> Bool {
+        return allRows.contains { row -> Bool in
+            if case .session(let viewModel) = row.kind {
+                return viewModel.identifier == session.sessionIdentifier
+            }
+            return false
+        }
+    }
+
+    // MARK: - Search
+
+    var filterResults = FilterResults.empty {
+        didSet {
+            filterResults.results {
+                self.updateWith(searchResults: $0, animated: true, selecting: nil)
+            }
+        }
+    }
+
+    // MARK: - UI
+
+    lazy var searchController = SearchFiltersViewController.loadFromStoryboard()
+
+    lazy var tableView: WWDCTableView = {
+        let v = WWDCTableView()
+
+        // We control the intial selection during initialization
+        v.allowsEmptySelection = true
+
+        v.wantsLayer = true
+        v.focusRingType = .none
+        v.allowsMultipleSelection = true
+        v.backgroundColor = .listBackground
+        v.headerView = nil
+        v.rowHeight = Metrics.sessionRowHeight
+        v.autoresizingMask = [.width, .height]
+        v.floatsGroupRows = true
+        v.gridStyleMask = .solidHorizontalGridLineMask
+        v.gridColor = .darkGridColor
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "session"))
+        v.addTableColumn(column)
+
+        return v
+    }()
+
+    lazy var scrollView: NSScrollView = {
+        let v = NSScrollView()
+
+        v.focusRingType = .none
+        v.backgroundColor = .listBackground
+        v.borderType = .noBorder
+        v.documentView = self.tableView
+        v.hasVerticalScroller = true
+        v.hasHorizontalScroller = false
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.alphaValue = 0
+
+        return v
+    }()
 
     // MARK: - Contextual menu
 
@@ -425,7 +447,7 @@ class SessionsTableViewController: NSViewController {
         tableView.menu = contextualMenu
     }
 
-    private func selectedRowIndexes() -> IndexSet {
+    private func selectedAndClickedRowIndexes() -> IndexSet {
         let clickedRow = tableView.clickedRow
         let selectedRowIndexes = tableView.selectedRowIndexes
 
@@ -439,7 +461,7 @@ class SessionsTableViewController: NSViewController {
     @objc private func tableViewMenuItemClicked(_ menuItem: NSMenuItem) {
         var viewModels = [SessionViewModel]()
 
-        selectedRowIndexes().forEach { row in
+        selectedAndClickedRowIndexes().forEach { row in
             guard case .session(let viewModel) = displayedRows[row].kind else { return }
 
             viewModels.append(viewModel)
@@ -466,7 +488,7 @@ class SessionsTableViewController: NSViewController {
     }
 
     override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        for row in selectedRowIndexes() {
+        for row in selectedAndClickedRowIndexes() {
             let sessionRow = displayedRows[row]
 
             guard case .session(let viewModel) = sessionRow.kind else { break }
@@ -511,18 +533,31 @@ class SessionsTableViewController: NSViewController {
     }
 }
 
-extension Session {
+private extension NSMenuItem {
 
-    var isWatched: Bool {
-        if let progress = progresses.first {
-            return progress.relativePosition > Constants.watchedVideoRelativePosition
+    var option: SessionsTableViewController.ContextualMenuOption {
+        get {
+            guard let value = SessionsTableViewController.ContextualMenuOption(rawValue: tag) else {
+                fatalError("Invalid ContextualMenuOption: \(tag)")
+            }
+
+            return value
         }
-
-        return false
+        set {
+            tag = newValue.rawValue
+        }
     }
+
 }
 
+// MARK: - Datasource / Delegate
+
 extension SessionsTableViewController: NSTableViewDataSource, NSTableViewDelegate {
+
+    fileprivate struct Metrics {
+        static let headerRowHeight: CGFloat = 20
+        static let sessionRowHeight: CGFloat = 64
+    }
 
     private struct Constants {
         static let sessionCellIdentifier = "sessionCell"
@@ -616,34 +651,4 @@ extension SessionsTableViewController: NSTableViewDataSource, NSTableViewDelegat
         }
     }
 
-}
-
-private extension NSMenuItem {
-
-    var option: SessionsTableViewController.ContextualMenuOption {
-        get {
-            guard let value = SessionsTableViewController.ContextualMenuOption(rawValue: tag) else {
-                fatalError("Invalid ContextualMenuOption: \(tag)")
-            }
-
-            return value
-        }
-        set {
-            tag = newValue.rawValue
-        }
-    }
-
-}
-
-private extension Array where Element == SessionRow {
-
-    func firstSessionRowIndex() -> Int? {
-        for (index, row) in enumerated() {
-            if case SessionRowKind.session = row.kind {
-                return index
-            }
-        }
-
-        return nil
-    }
 }

--- a/WWDC/TextualFilter.swift
+++ b/WWDC/TextualFilter.swift
@@ -54,6 +54,10 @@ struct TextualFilter: FilterType {
         return NSCompoundPredicate(orPredicateWithSubpredicates: subpredicates)
     }
 
+    mutating func reset() {
+        value = nil
+    }
+
     func dictionaryRepresentation() -> WWDCFilterTypeDictionary {
         var dictionary: WWDCFilterTypeDictionary = WWDCFilterTypeDictionary()
 

--- a/WWDC/ToggleFilter.swift
+++ b/WWDC/ToggleFilter.swift
@@ -12,6 +12,7 @@ struct ToggleFilter: FilterType {
 
     var identifier: String
     var isOn: Bool
+    var defaultValue: Bool
 
     var customPredicate: NSPredicate?
 
@@ -23,6 +24,10 @@ struct ToggleFilter: FilterType {
         guard isOn else { return nil }
 
         return customPredicate
+    }
+
+    mutating func reset() {
+        isOn = defaultValue
     }
 
     func dictionaryRepresentation() -> WWDCFilterTypeDictionary {


### PR DESCRIPTION
fixes #395

It clears active filters if they're preventing navigation. 
Provides an abstraction of delivering filter queries and allows the session table view to be a little more involved. I did this for flexibility when updating the table, though I'm not currently taken advantage of the flexibility it affords because I initially started down this path thinking I would be forcing items into the list that are navigated to. The solution leaves the responsibility of creating the search predicate in the SearchCooridinator, which is good I think. I also reorganized the code to make the file a little more approachable by moving supporting stuff into a separate file!

I can no longer test this because my featured content has stopped populating! Please help @insidegui 