### PR TITLE
Fixes reported layout ambiguity

### DIFF
--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -98,6 +98,8 @@ class SessionSummaryViewController: NSViewController {
         let v = NSStackView(views: [self.contextLabel, self.actionLinkLabel])
 
         v.orientation = .horizontal
+        v.alignment = .top
+        v.distribution = .fillProportionally
         v.spacing = 16
         v.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
This was a small issue being reported by the view debugger. The default values for NSStackView are not appropriate for just about anything :-( 