### PR TITLE
Add support for seeking videos using keyboard arrows

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1129,11 +1129,11 @@ public final class PUIPlayerView: NSView {
                 return nil
 
             case .leftArrow:
-                self.goBackInTime15(nil)
+                self.goBackInTime(nil)
                 return nil
 
             case .rightArrow:
-                self.goForwardInTime15(nil)
+                self.goForwardInTime(nil)
                 return nil
             }
         }

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1103,6 +1103,8 @@ public final class PUIPlayerView: NSView {
 
     private enum KeyCommands: UInt16 {
         case spaceBar = 49
+        case leftArrow = 123
+        case rightArrow = 124
     }
 
     private func startMonitoringKeyEvents() {
@@ -1124,6 +1126,14 @@ public final class PUIPlayerView: NSView {
             switch command {
             case .spaceBar:
                 self.togglePlaying(nil)
+                return nil
+
+            case .leftArrow:
+                self.goBackInTime15(nil)
+                return nil
+
+            case .rightArrow:
+                self.goForwardInTime15(nil)
                 return nil
             }
         }


### PR DESCRIPTION
Hey! 👋

I just started watching this year's WWDC videos using your fantastic app and found myself pressing the left/right keyboard arrows on multiple occasions, expecting them to seek backward/forward just like the buttons in the UI. Seeing as there were already at least two other people (#412 and #425) asking for the same thing, I decided to take a stab at implementing this feature!

**Summary**
This pull request adds support for going _back_ 15/30 seconds in a video using the _left_ keyboard arrow, and going _forward_ 15/30 seconds in a video using the _right_ keyboard arrow.

Let me know if there's anything I've missed in my implementation! 🙂