### PR TITLE
Enabled indexing of transcripts for 2017 and 2018

### DIFF
--- a/ConfCore/TranscriptIndexer.swift
+++ b/ConfCore/TranscriptIndexer.swift
@@ -43,7 +43,7 @@ public final class TranscriptIndexer {
 
     public static let minTranscriptableSessionLimit: Int = 20
     // TODO: increase 2017 to 2018 when transcripts for 2017 become available
-    public static let transcriptableSessionsPredicate: NSPredicate = NSPredicate(format: "ANY event.year > 2012 AND ANY event.year < 2017 AND transcriptIdentifier == '' AND SUBQUERY(assets, $asset, $asset.rawAssetType == %@).@count > 0", SessionAssetType.streamingVideo.rawValue)
+    public static let transcriptableSessionsPredicate: NSPredicate = NSPredicate(format: "ANY event.year > 2012 AND ANY event.year <= 2018 AND transcriptIdentifier == '' AND SUBQUERY(assets, $asset, $asset.rawAssetType == %@).@count > 0", SessionAssetType.streamingVideo.rawValue)
 
     public static func needsUpdate(in storage: Storage) -> Bool {
         let transcriptedSessions = storage.realm.objects(Session.self).filter(TranscriptIndexer.transcriptableSessionsPredicate)

--- a/ConfCore/TranscriptIndexer.swift
+++ b/ConfCore/TranscriptIndexer.swift
@@ -42,7 +42,8 @@ public final class TranscriptIndexer {
     }()
 
     public static let minTranscriptableSessionLimit: Int = 20
-    // TODO: increase 2017 to 2018 when transcripts for 2017 become available
+
+    // We specify the latest year known to have transcripts in the predicate to avoid firing lots of requests to ASCIIWWDC which would result in a 404
     public static let transcriptableSessionsPredicate: NSPredicate = NSPredicate(format: "ANY event.year > 2012 AND ANY event.year <= 2018 AND transcriptIdentifier == '' AND SUBQUERY(assets, $asset, $asset.rawAssetType == %@).@count > 0", SessionAssetType.streamingVideo.rawValue)
 
     public static func needsUpdate(in storage: Storage) -> Bool {


### PR DESCRIPTION
ASCIIWWDC has been updated with transcripts for 2017 and 2018, this changes the predicate for the indexing of transcripts which disabled `> 2017` events.