### PR TITLE
Fixes #468 crash and session display issue

### DIFF
--- a/ConfCore/SyncEngine.swift
+++ b/ConfCore/SyncEngine.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 extension Notification.Name {
     public static let SyncEngineDidSyncSessionsAndSchedule = Notification.Name("SyncEngineDidSyncSessionsAndSchedule")
+    public static let SyncEngineDidSyncFeaturedSections = Notification.Name("SyncEngineDidSyncFeaturedSections")
 }
 
 public final class SyncEngine {
@@ -81,7 +82,9 @@ public final class SyncEngine {
     public func syncFeaturedSections() {
         client.fetchFeaturedSections { [weak self] result in
             DispatchQueue.main.async {
-                self?.storage.store(featuredSectionsResult: result)
+                self?.storage.store(featuredSectionsResult: result) { error in
+                    NotificationCenter.default.post(name: .SyncEngineDidSyncFeaturedSections, object: error)
+                }
             }
         }
     }

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -134,7 +134,7 @@ class SessionsTableViewController: NSViewController {
     /// even if its data model gets added while it is offscreen. Specifically,
     /// when this table view is not the initial active tab.
     private func performFirstUpdateIfNeeded() {
-        guard !hasPerformedFirstUpdate else { return }
+        guard !hasPerformedFirstUpdate && sessionRowProvider != nil else { return }
         hasPerformedFirstUpdate = true
 
         filterResults.results { [weak self] in
@@ -183,6 +183,7 @@ class SessionsTableViewController: NSViewController {
     var sessionRowProvider: SessionRowProvider? {
         didSet {
             allRows = sessionRowProvider?.sessionRows() ?? []
+            performFirstUpdateIfNeeded()
         }
     }
 


### PR DESCRIPTION
Follows pattern already applied to other data. Captures the featured content as required to dismiss the spinner on first launch. Ensures featured section contents get deleted as well as the sections (I had 1000k FeaturedContent objects in my table because it kept creating new ones).

Fixes an issue with the sessions list tabs so that they display immediately on app launch instead of waiting for the sync to happen.

It had to fix this crash because I got to a point where it was 100%, this might not be the most correct way to handle the data, though. But it no longer crashes