### PR TITLE
Player buttons now accept first mouse, allowing play/pause while not frontmost

### DIFF
--- a/PlayerUI/Views/PUIButton.swift
+++ b/PlayerUI/Views/PUIButton.swift
@@ -185,4 +185,8 @@ public final class PUIButton: NSControl {
         return true
     }
 
+    public override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        return true
+    }
+
 }


### PR DESCRIPTION
While taking notes I found myself trying to pause the video at a spot while my notes application was active only to need to click twice to pause. This exposes all the PUIPlayerButtons so they can be clicked while the app is not active.