### PR TITLE
Bug fix (#463): When tapping on non-editable text, player shortcut events get swallowed

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1123,7 +1123,7 @@ public final class PUIPlayerView: NSView {
 
             let allWindows = NSApp.windows
             let firstResponders = allWindows.compactMap { $0.firstResponder }
-            let fieldEditors = firstResponders.filter { ($0 as? NSText)?.isFieldEditor == true }
+            let fieldEditors = firstResponders.filter { ($0 as? NSText)?.isEditable == true }
             guard fieldEditors.isEmpty else { return event }
             guard !self.timelineView.isEditingAnnotation else { return event }
 


### PR DESCRIPTION
This issue happened, for example, if the user tapped in the description area underneath the player, which caused the labels to become first responders. However, these labels cannot be edited, unlike the search bar on the left pane of the app, causing frustrating behaviour due to keyboard shortcuts sometimes working and sometimes not for no apparent reason.