### PR TITLE
Improves players handling of information loading to prevent hangs

### DIFF
--- a/PlayerUI/Util/AVAsset+AsyncHelpers.swift
+++ b/PlayerUI/Util/AVAsset+AsyncHelpers.swift
@@ -1,0 +1,22 @@
+//
+//  AVAsset+AsyncHelpers.swift
+//  PlayerUI
+//
+//  Created by Allen Humphreys on 6/25/18.
+//  Copyright © 2018 Guilherme Rambo. All rights reserved.
+//
+
+import AVFoundation
+
+extension AVAsset {
+
+    public var durationIfLoaded: CMTime? {
+
+        let error: NSErrorPointer = nil
+        let durationStatus = statusOfValue(forKey: "duration", error: error)
+
+        guard durationStatus == .loaded, error?.pointee == nil else { return nil }
+
+        return duration
+    }
+}

--- a/PlayerUI/Util/AVPlayer+Validation.swift
+++ b/PlayerUI/Util/AVPlayer+Validation.swift
@@ -20,9 +20,9 @@ extension AVPlayer {
     }
 
     var hasValidMediaDuration: Bool {
-        guard let item = currentItem else { return false }
+        guard let duration = currentItem?.asset.durationIfLoaded else { return false }
 
-        return AVPlayer.validateMediaDuration(item.duration)
+        return AVPlayer.validateMediaDuration(duration)
     }
 
 }

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -247,11 +247,9 @@ public final class PUIPlayerView: NSView {
 
         asset?.loadValuesAsynchronously(forKeys: ["duration"], completionHandler: durationBecameAvailable)
 
-        // This produces a log message: `-[AVAsset statusOfValueForKey:error:] invoked with unrecognized key allMediaSelections.`
-        // But it works correctly
-        asset?.loadValuesAsynchronously(forKeys: ["allMediaSelections"], completionHandler: { [weak self] in
+        asset?.loadValuesAsynchronously(forKeys: ["availableMediaCharacteristicsWithMediaSelectionOptions"], completionHandler: { [weak self] in
 
-            if self?.asset?.statusOfValue(forKey: "allMediaSelections", error: nil) == .loaded {
+            if self?.asset?.statusOfValue(forKey: "availableMediaCharacteristicsWithMediaSelectionOptions", error: nil) == .loaded {
                 self?.updateSubtitleSelectionMenu()
             }
         })

--- a/PlayerUI/Views/PUITimelineView.swift
+++ b/PlayerUI/Views/PUITimelineView.swift
@@ -43,12 +43,6 @@ public final class PUITimelineView: NSView {
 
     public weak var delegate: PUITimelineDelegate?
 
-    public var bufferingProgress: Double = 0 {
-        didSet {
-            layoutBufferingLayer()
-        }
-    }
-
     public var playbackProgress: Double = 0 {
         didSet {
             layoutPlaybackLayer()

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		3A0840B41F924665002BC828 /* Realm+InMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0840B31F924665002BC828 /* Realm+InMemory.swift */; };
 		3A6227031F9272A300D5F687 /* contents.json in Resources */ = {isa = PBXBuildFile; fileRef = 3A6227021F9272A300D5F687 /* contents.json */; };
 		4D5EB0F820598E6000D4BC52 /* SessionRowProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */; };
+		4DBFA4DA20E160CB00BDF34B /* AVAsset+AsyncHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFA4D920E160CB00BDF34B /* AVAsset+AsyncHelpers.swift */; };
 		4DEEC3A32051C8D400376595 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DEEC3A22051C8D400376595 /* TestUtilities.swift */; };
 		4DF6641620C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6641520C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift */; };
 		DD0159A71ECFE26200F980F1 /* DeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD0159A61ECFE26200F980F1 /* DeepLink.swift */; };
@@ -353,6 +354,7 @@
 		3A0840B31F924665002BC828 /* Realm+InMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Realm+InMemory.swift"; sourceTree = "<group>"; };
 		3A6227021F9272A300D5F687 /* contents.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = contents.json; sourceTree = "<group>"; };
 		4D5EB0F720598E6000D4BC52 /* SessionRowProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRowProvider.swift; sourceTree = "<group>"; };
+		4DBFA4D920E160CB00BDF34B /* AVAsset+AsyncHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAsset+AsyncHelpers.swift"; sourceTree = "<group>"; };
 		4DEEC3A22051C8D400376595 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		4DF6641520C8A85000FD1684 /* SessionsTableViewController+SupportingTypesAndExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionsTableViewController+SupportingTypesAndExtensions.swift"; sourceTree = "<group>"; };
 		DD0159A61ECFE26200F980F1 /* DeepLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeepLink.swift; sourceTree = "<group>"; };
@@ -1494,6 +1496,7 @@
 			isa = PBXGroup;
 			children = (
 				DDF721B91ECA12A40054C503 /* AVPlayer+Validation.swift */,
+				4DBFA4D920E160CB00BDF34B /* AVAsset+AsyncHelpers.swift */,
 				DDF721BB1ECA12A40054C503 /* NSEvent+ForceTouch.swift */,
 				DDF721BC1ECA12A40054C503 /* NSWindow+Snapshot.swift */,
 				DDF721BD1ECA12A40054C503 /* String+CMTime.swift */,
@@ -1853,7 +1856,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 		F72964482015787100A7A571 /* SwiftLint Warnings */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2092,6 +2095,7 @@
 				DDC970BF209291630072B822 /* PUITouchBarController.swift in Sources */,
 				DDF721E01ECA12A40054C503 /* PUISlider.swift in Sources */,
 				DDF721DA1ECA12A40054C503 /* PUIAnnotationLayer.swift in Sources */,
+				4DBFA4DA20E160CB00BDF34B /* AVAsset+AsyncHelpers.swift in Sources */,
 				DDF721CC1ECA12A40054C503 /* PUIExternalPlaybackProviderRegistration.swift in Sources */,
 				DDF721C91ECA12A40054C503 /* Colors.swift in Sources */,
 				DDED75571ED3C1BF000BA817 /* PUIScrimContainerView.swift in Sources */,

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -1853,7 +1853,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "#/usr/local/bin/carthage copy-frameworks";
 		};
 		F72964482015787100A7A571 /* SwiftLint Warnings */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/WWDC/PlaybackViewModel.swift
+++ b/WWDC/PlaybackViewModel.swift
@@ -139,7 +139,14 @@ final class PlaybackViewModel {
             player.seek(to: CMTimeMakeWithSeconds(Float64(p), 9000))
 
             timeObserver = player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(5, 9000), queue: DispatchQueue.main) { [weak self] currentTime in
-                guard let duration = self?.player.currentItem?.asset.duration else { return }
+                guard let asset = self?.player.currentItem?.asset else { return }
+                let error: NSErrorPointer = nil
+                let durationStatus = asset.statusOfValue(forKey: "duration", error: error)
+
+                guard durationStatus == AVKeyValueStatus.loaded else { return }
+
+                let duration = asset.duration
+
                 guard CMTIME_IS_VALID(duration) else { return }
 
                 let p = Double(CMTimeGetSeconds(currentTime))

--- a/WWDC/PlaybackViewModel.swift
+++ b/WWDC/PlaybackViewModel.swift
@@ -139,22 +139,18 @@ final class PlaybackViewModel {
             player.seek(to: CMTimeMakeWithSeconds(Float64(p), 9000))
 
             timeObserver = player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(5, 9000), queue: DispatchQueue.main) { [weak self] currentTime in
-                guard let asset = self?.player.currentItem?.asset else { return }
-                let error: NSErrorPointer = nil
-                let durationStatus = asset.statusOfValue(forKey: "duration", error: error)
+                guard let `self` = self else { return }
 
-                guard durationStatus == AVKeyValueStatus.loaded else { return }
-
-                let duration = asset.duration
+                guard let duration = self.player.currentItem?.asset.durationIfLoaded else { return }
 
                 guard CMTIME_IS_VALID(duration) else { return }
 
                 let p = Double(CMTimeGetSeconds(currentTime))
                 let d = Double(CMTimeGetSeconds(duration))
 
-                self?.sessionViewModel.session.setCurrentPosition(p, d)
+                self.sessionViewModel.session.setCurrentPosition(p, d)
 
-                if !d.isZero { self?.nowPlayingInfo.value?.progress = p / d }
+                if !d.isZero { self.nowPlayingInfo.value?.progress = p / d }
             }
         }
     }

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -523,7 +523,7 @@ class SessionsTableViewController: NSViewController {
 
             return canMarkAsWatched
         case .unwatched:
-            return viewModel.session.isWatched
+            return viewModel.session.isWatched || viewModel.session.progresses.count > 0
         case .favorite:
             return !viewModel.isFavorite
         case .removeFavorite:

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -105,7 +105,11 @@ class ShelfViewController: NSViewController {
     }
 
     @objc private func play(_ sender: Any?) {
-        delegate?.shelfViewControllerDidSelectPlay(self)
+
+        // Dispatch to let the button continue
+        DispatchQueue.main.async {
+            self.delegate?.shelfViewControllerDidSelectPlay(self)
+        }
     }
 
 }


### PR DESCRIPTION
...especially for users on slower internet connections

Fixes #465

I also put in some very basic error handling for displaying AVFoundation errors and subsequently reset the player after the error state is entered. When changing videos, the player resets some state to avoid having the controls show information from the previous video while loading the new one. The loading spinner will show after a brief delay, otherwise it may appear to flash on then off. The length of the delay is up for debate.

I'd like feedback on my approach and a little help testing.