### PR TITLE
Replace layer-based filtering with one-time image filtering for blurred effect

### DIFF
--- a/PlayerUI/Controllers/PUIExternalPlaybackStatusViewController.swift
+++ b/PlayerUI/Controllers/PUIExternalPlaybackStatusViewController.swift
@@ -10,9 +10,39 @@ import Cocoa
 
 class PUIExternalPlaybackStatusViewController: NSViewController {
 
-    var snapshot: NSImage? {
+    private let blurFilter: CIFilter = {
+        let f = CIFilter(name: "CIGaussianBlur")!
+        f.setValue(100, forKey: kCIInputRadiusKey)
+        return f
+    }()
+
+    private let saturationFilter: CIFilter = {
+        let f = CIFilter(name: "CIColorControls")!
+        f.setDefaults()
+        f.setValue(2, forKey: kCIInputSaturationKey)
+        return f
+    }()
+
+    private let context = CIContext()
+
+    var snapshot: CGImage? {
         didSet {
-            snapshotLayer.contents = snapshot
+            guard let cgImage = snapshot else {
+                snapshotLayer.contents = nil
+                return
+            }
+
+            let targetSize = snapshotLayer.bounds
+            let transform = CGAffineTransform(scaleX: targetSize.width / CGFloat(cgImage.width),
+                                              y: targetSize.height / CGFloat(cgImage.height))
+
+            let ciImage = CIImage(cgImage: cgImage).transformed(by: transform)
+
+            if let filteredImage = ciImage.filtered(with: [saturationFilter, blurFilter]),
+                let cgImage = context.createCGImage(filteredImage, from: ciImage.extent) {
+
+                snapshotLayer.contents = cgImage
+            }
         }
     }
     var providerIcon: NSImage? {
@@ -94,26 +124,32 @@ class PUIExternalPlaybackStatusViewController: NSViewController {
         view.layer?.masksToBounds = true
         view.layer?.backgroundColor = NSColor.black.cgColor
 
-        view.layerUsesCoreImageFilters = true
-
         snapshotLayer.frame = view.bounds
         view.layer?.addSublayer(snapshotLayer)
-
-        if let blur = CIFilter(name: "CIGaussianBlur"), let sat = CIFilter(name: "CIColorControls") {
-            sat.setDefaults()
-            sat.setValue(2, forKey: "inputSaturation")
-            blur.setValue(100, forKey: "inputRadius")
-            snapshotLayer.filters = [sat, blur]
-        }
 
         view.addSubview(stackView)
         stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
     }
+}
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do view setup here.
+extension CIImage {
+
+    func filtered(with ciFilters: [CIFilter]) -> CIImage? {
+
+        var inputImage = self.clampedToExtent()
+
+        var finalFilter: CIFilter?
+        for filter in ciFilters {
+            finalFilter = filter
+
+            filter.setValue(inputImage, forKey: kCIInputImageKey)
+
+            if let output = filter.outputImage {
+                inputImage = output
+            }
+        }
+
+        return finalFilter?.outputImage
     }
-
 }

--- a/PlayerUI/Controllers/PUIExternalPlaybackStatusViewController.swift
+++ b/PlayerUI/Controllers/PUIExternalPlaybackStatusViewController.swift
@@ -27,21 +27,18 @@ class PUIExternalPlaybackStatusViewController: NSViewController {
 
     var snapshot: CGImage? {
         didSet {
-            guard let cgImage = snapshot else {
-                snapshotLayer.contents = nil
-                return
-            }
+            snapshotLayer.contents = snapshot.flatMap { cgImage in
 
-            let targetSize = snapshotLayer.bounds
-            let transform = CGAffineTransform(scaleX: targetSize.width / CGFloat(cgImage.width),
-                                              y: targetSize.height / CGFloat(cgImage.height))
+                let targetSize = snapshotLayer.bounds
+                let transform = CGAffineTransform(scaleX: targetSize.width / CGFloat(cgImage.width),
+                                                  y: targetSize.height / CGFloat(cgImage.height))
 
-            let ciImage = CIImage(cgImage: cgImage).transformed(by: transform)
+                let ciImage = CIImage(cgImage: cgImage).transformed(by: transform)
+                let filters = [saturationFilter, blurFilter]
 
-            if let filteredImage = ciImage.filtered(with: [saturationFilter, blurFilter]),
-                let cgImage = context.createCGImage(filteredImage, from: ciImage.extent) {
+                guard let filteredImage = ciImage.filtered(with: filters) else { return nil }
 
-                snapshotLayer.contents = cgImage
+                return context.createCGImage(filteredImage, from: ciImage.extent)
             }
         }
     }

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1182,7 +1182,7 @@ public final class PUIPlayerView: NSView {
 
     // MARK: - PiP Support
 
-    public func snapshotPlayer(completion: @escaping (NSImage?) -> Void) {
+    public func snapshotPlayer(completion: @escaping (CGImage?) -> Void) {
         guard let currentTime = player?.currentTime() else {
             completion(nil)
             return
@@ -1202,8 +1202,7 @@ public final class PUIPlayerView: NSView {
                 return
             }
 
-            let image = NSImage(cgImage: rawImage, size: NSSize(width: rawImage.width, height: rawImage.height))
-            DispatchQueue.main.async { completion(image) }
+            DispatchQueue.main.async { completion(rawImage) }
         }
     }
 

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -303,11 +303,12 @@ extension VideoPlayerViewController: PUIPlayerViewDelegate {
 
     func playerViewDidSelectAddAnnotation(_ playerView: PUIPlayerView, at timestamp: Double) {
         snapshotPlayer { snapshot in
-            self.delegate?.createBookmark(at: timestamp, with: snapshot)
+            self.delegate?.createBookmark(at: timestamp,
+                                          with: snapshot.map { NSImage(cgImage: $0, size: NSSize(width: $0.width, height: $0.height)) })
         }
     }
 
-    private func snapshotPlayer(completion: @escaping (NSImage?) -> Void) {
+    private func snapshotPlayer(completion: @escaping (CGImage?) -> Void) {
         playerView.snapshotPlayer(completion: completion)
     }
 


### PR DESCRIPTION
According to the docs for `layerUsesCoreImageFilters`
> Specifying true for property lets AppKit know that it must move rendering of the layer hierarchy back into your app’s process.

The in-process rendering seems to have been impacting performance of the layout/rendering of other parts of the app, namely the sessions table view animations.