### PR TITLE
Live updating filter queries

### DIFF
--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -41,7 +41,10 @@ final class AppCoordinator {
     var playerOwnerTab: MainWindowTab?
 
     /// The session that "owns" the current player (the one that was selected on the active tab when "play" was pressed)
-    var playerOwnerSessionIdentifier: String?
+    var playerOwnerSessionIdentifier: String? {
+        didSet { rxPlayerOwnerSessionIdentifier.onNext(playerOwnerSessionIdentifier) }
+    }
+    var rxPlayerOwnerSessionIdentifier = BehaviorSubject<String?>(value: nil)
 
     /// Whether we're currently in the middle of a player context transition
     var isTransitioningPlayerContext = false

--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -204,14 +204,7 @@ final class SearchCoordinator {
             subpredicates.append(Session.videoPredicate)
         }
 
-        var predicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
-
-        if let appDelegate = NSApplication.shared.delegate as? AppDelegate,
-            let currentlyPlayingSession = appDelegate.coordinator.currentPlayerController?.sessionViewModel.session {
-
-            // Keep the currently playing video in the list to ensure PIP can re-select it if needed
-            predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [predicate, NSPredicate(format: "identifier == %@", currentlyPlayingSession.identifier)])
-        }
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: subpredicates)
 
         os_log("%{public}@", log: log, type: .debug, String(describing: predicate))
 

--- a/WWDC/WWDCTableView.swift
+++ b/WWDC/WWDCTableView.swift
@@ -10,14 +10,6 @@ import Cocoa
 
 class WWDCTableView: NSTableView {
 
-    private var selectedRowIndexesBeforeReload: IndexSet = IndexSet([])
-
-    func reloadPreservingSelection() {
-        selectedRowIndexesBeforeReload = selectedRowIndexes
-        reloadData()
-        selectRowIndexes(selectedRowIndexesBeforeReload, byExtendingSelection: false)
-    }
-
     override var effectiveAppearance: NSAppearance {
         return NSAppearance(named: .vibrantDark)!
     }


### PR DESCRIPTION
This makes filter results update in response to live changes. i.e. if you have the favorites filter on and un-favorite a video, it will be removed immediately.

Also, the forced "now playing" query is updated, so if your current query doesn't include the now playing session and you play a different session, that session will be removed. 👍 

It also has some fixes/improvements to the lists initializations.