### PR TITLE
Some realm/rx optimizations

### DIFF
--- a/WWDC/PlaybackViewModel.swift
+++ b/WWDC/PlaybackViewModel.swift
@@ -35,7 +35,7 @@ extension Session {
         if type == .image {
             return imageAsset()
         } else {
-            let filtered = assets.filter({ $0.assetType == type })
+            let filtered = assets.filter("rawAssetType == %@", type.rawValue)
             return filtered.first
         }
     }


### PR DESCRIPTION
For `SessionViewModel`, by only creating a single `Observable` for the session, we're reducing the number of realm observers and instead relying on Rx to multiplex a single observer callback into many destinations.

For `PlaybackViewModel`, using predicate format leverages Realm's query powers to optimize db access.