### PR TITLE
Fix buffer layer resize behaviour

### DIFF
--- a/PlayerUI/Views/PUIBufferLayer.swift
+++ b/PlayerUI/Views/PUIBufferLayer.swift
@@ -21,7 +21,7 @@ struct PUIBufferSegment: Hashable {
     }
 }
 
-final class PUIBufferLayer: CALayer {
+final class PUIBufferLayer: PUIBoringLayer {
 
     var segments = Set<PUIBufferSegment>() {
         didSet {


### PR DESCRIPTION
All the other layers are boring layers, this seems to be a miss. The change keeps the buffered layer from incorrectly animated when window resizing. Much like the outline layer and progress layer.