### PR TITLE
Fixes Xcode-independent warnings preparing for Xcode 10

### DIFF
--- a/ConfCore/Storage.swift
+++ b/ConfCore/Storage.swift
@@ -49,12 +49,14 @@ public final class Storage {
         return try Realm(configuration: realmConfig)
     }
 
+    private lazy var dispatchQueue = DispatchQueue(label: "WWDC Storage", qos: .background)
+
     public lazy var storageQueue: OperationQueue = {
         let q = OperationQueue()
 
         q.name = "WWDC Storage"
         q.maxConcurrentOperationCount = 1
-        q.underlyingQueue = DispatchQueue(label: "WWDC Storage", qos: .background)
+        q.underlyingQueue = dispatchQueue
 
         return q
     }()

--- a/WWDC/ImageDownloadCenter.swift
+++ b/WWDC/ImageDownloadCenter.swift
@@ -153,7 +153,7 @@ private final class ImageDownloadOperation: Operation {
         self.thumbnailHeight = thumbnailHeight
     }
 
-    open override var isAsynchronous: Bool {
+    public override var isAsynchronous: Bool {
         return true
     }
 
@@ -166,7 +166,7 @@ private final class ImageDownloadOperation: Operation {
         }
     }
 
-    open override var isExecuting: Bool {
+    public override var isExecuting: Bool {
         return _executing
     }
 
@@ -179,7 +179,7 @@ private final class ImageDownloadOperation: Operation {
         }
     }
 
-    open override var isFinished: Bool {
+    public override var isFinished: Bool {
         return _finished
     }
 


### PR DESCRIPTION
No implementation changes, just addresses new warnings that surface when using Xcode 10. I would've addressed them alongside something else, but the next task I'm working on might take a while.