### PR TITLE
Bug fix (#458): Playback Speed reverts to 1x after switching videos

### DIFF
--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -143,9 +143,8 @@ final class VideoPlayerViewController: NSViewController {
 
         setupPlayerObservers()
 
-        player.play()
-
         playerView.player = player
+        playerView.play(self)
 
         if let playbackViewModel = playbackViewModel {
             playerView.remoteMediaUrl = playbackViewModel.remoteMediaURL


### PR DESCRIPTION
The root of the issue is that between videos, the internal AVPlayer instance is recreated to stream/play the new video, and when this happens, the playback speed state isn't properly restored. There are a couple of ways to go about fixing this issue, we picked here what seemed the most architecturally-sound.