### PR TITLE
Removed the year from the label for non-WWDC events

### DIFF
--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -193,13 +193,12 @@ final class SessionViewModel {
         guard let event = event else { return "" }
 
         let year = Calendar.current.component(.year, from: event.startDate)
+        var name = event.name
 
-        // Currently, there's only one event which is not a WWDC (the "Fall 2017" event),
-        // for some reason it includes the year on its name, while WWDC editions do not,
-        // so we have to use this workaround to avoid displaying the year twice
-        var name = event.name.replacingOccurrences(of: " \(year)", with: "")
-
-        //We only want to add the year to WWDC event names.
+        /*
+        We want to make sure that WWDC events show the year
+        So we add it it not present.
+        */
         if name == "WWDC" {
             name.append(" \(year)")
         }

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -197,9 +197,14 @@ final class SessionViewModel {
         // Currently, there's only one event which is not a WWDC (the "Fall 2017" event),
         // for some reason it includes the year on its name, while WWDC editions do not,
         // so we have to use this workaround to avoid displaying the year twice
-        let name = event.name.replacingOccurrences(of: " \(year)", with: "")
+        var name = event.name.replacingOccurrences(of: " \(year)", with: "")
 
-        return "\(name) \(year) · Session \(session.number)"
+        //We only want to add the year to WWDC event names.
+        if name == "WWDC" {
+            name.append(" \(year)")
+        }
+
+        return "\(name) · Session \(session.number)"
     }
 
     static func focusesDescription(from focuses: [Focus], collapse: Bool) -> String {


### PR DESCRIPTION
From issue #504 : "We only want to append the year to "WWDC" event names, without altering any other event names."

This PR fixes this problem.
If you can think of any better solution I'm happy to edit this😊