### PR TITLE
Allow selecting the session title in the summary

### DIFF
--- a/WWDC/SessionSummaryViewController.swift
+++ b/WWDC/SessionSummaryViewController.swift
@@ -37,6 +37,10 @@ class SessionSummaryViewController: NSViewController {
         l.allowsDefaultTighteningForTruncation = true
         l.maximumNumberOfLines = 2
         l.translatesAutoresizingMaskIntoConstraints = false
+        l.isSelectable = true
+        // This prevents the text field from stripping attributes
+        // during selection. 
+        l.allowsEditingTextAttributes = true
 
         return l
     }()


### PR DESCRIPTION
It bothered me a while back that I couldn't do this. Seems like something people might want to do occasionally. For example,

Me: I just watched a great WWDC session!
Friend: What was it called?
Me: ....
Me: ........
Me: ....
Me: Designing for Apple Watch Series 4
Me: I tried to copy and paste but I couldn't!

![selecttitle](https://user-images.githubusercontent.com/8225090/47385094-ba2e3e80-d6ce-11e8-880b-5522512b1d1e.gif)