### PR TITLE
Calendar icon is now a template, add calendar usage string

### DIFF
--- a/WWDC/AppCoordinator+SessionTableViewContextMenuActions.swift
+++ b/WWDC/AppCoordinator+SessionTableViewContextMenuActions.swift
@@ -11,7 +11,6 @@ import RealmSwift
 import RxSwift
 import ConfCore
 import PlayerUI
-import EventKit
 
 extension AppCoordinator: SessionsTableViewControllerDelegate {
 

--- a/WWDC/Assets.xcassets/calendar.imageset/Contents.json
+++ b/WWDC/Assets.xcassets/calendar.imageset/Contents.json
@@ -14,5 +14,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WWDC/Info.plist
+++ b/WWDC/Info.plist
@@ -76,6 +76,8 @@
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Calendar access allows you to add events directly from the app to help you plan your WWDC week.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Guilherme Rambo. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>


### PR DESCRIPTION
Fixes #423 as well as the secret incorrect icon color (it wasn't set to template in the asset catalogue).