### PR TITLE
Fixed iCloud build configuration (Closes #521)

### DIFF
--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC_iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC_iCloud.xcscheme
@@ -52,7 +52,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug with iCloud"
+      buildConfiguration = "Debug_iCloud"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -145,7 +145,7 @@
       buildConfiguration = "Debug with iCloud">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release with iCloud"
+      buildConfiguration = "Release_iCloud"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
The issue was caused by the renaming of the build configurations, which caused the release to be built without iCloud support, even tho the iCloud-enabled scheme was selected.