### PR TITLE
Refine errors presented to the user

### DIFF
--- a/ConfCore/Resource+Error.swift
+++ b/ConfCore/Resource+Error.swift
@@ -9,20 +9,52 @@
 import Foundation
 import Siesta
 
-public enum APIError: Error {
+public enum APIError: Error, CustomNSError {
     case http(Error)
     case adapter
     case unknown
 
     public var localizedDescription: String {
         switch self {
-        case .http(let error):
+        case let .http(error as RequestError):
+            return error.userMessage
+        case let .http(error):
             return error.localizedDescription
         case .adapter:
             return "Unable to process the data returned by the server"
         case .unknown:
             return "An unknown networking error occurred"
         }
+    }
+
+    public static var errorDomain: String {
+        return "io.wwdc.error"
+    }
+
+    public var errorCode: Int {
+        switch self {
+        case .http: return 0
+        case .adapter: return 1
+        case .unknown: return 2
+        }
+    }
+
+    /// The user-info dictionary.
+    public var errorUserInfo: [String: Any] {
+        var userInfo = [NSLocalizedDescriptionKey: localizedDescription]
+
+        switch self {
+        case let .http(underlying as RequestError) where underlying.cause != nil && (underlying.cause! as NSError).domain == NSURLErrorDomain:
+            let underlyingUserInfo = (underlying.cause! as NSError).userInfo.compactMapValues { $0 as? String }
+            userInfo.merge(underlyingUserInfo, uniquingKeysWith: { $1 })
+            userInfo[NSLocalizedRecoverySuggestionErrorKey] = "Please try again"
+        case let .http(underlying as RequestError) where underlying.cause != nil && underlying.cause! is DecodingError:
+            userInfo[NSLocalizedRecoverySuggestionErrorKey] = "Please report this error"
+        case .adapter, .unknown, .http:
+            ()
+        }
+
+        return userInfo
     }
 }
 

--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -316,7 +316,7 @@ final class AppCoordinator {
 
         _ = NotificationCenter.default.addObserver(forName: .SyncEngineDidSyncSessionsAndSchedule, object: nil, queue: .main) { note in
             if let error = note.object as? Error {
-                NSApp.presentError(error)
+                WWDCAlert.show(with: error)
             } else {
                 self.updateListsAfterSync(migrate: true)
             }
@@ -324,7 +324,7 @@ final class AppCoordinator {
 
         _ = NotificationCenter.default.addObserver(forName: .SyncEngineDidSyncFeaturedSections, object: nil, queue: .main) { note in
             if let error = note.object as? Error {
-                NSApp.presentError(error)
+                WWDCAlert.show(with: error)
             } else {
                 self.updateFeaturedSectionsAfterSync()
             }


### PR DESCRIPTION
Before:
<img width="532" alt="Screen Shot 2019-05-01 at 10 18 59 AM" src="https://user-images.githubusercontent.com/8225090/57052890-ddbedc80-6c4f-11e9-9c98-afd2ce8d17e1.png">

After:
<img width="532" alt="Screen Shot 2019-05-01 at 10 18 06 AM" src="https://user-images.githubusercontent.com/8225090/57052891-e1eafa00-6c4f-11e9-86c6-da50273e1425.png">
<img width="532" alt="Screen Shot 2019-05-01 at 10 19 55 AM" src="https://user-images.githubusercontent.com/8225090/57052895-e3b4bd80-6c4f-11e9-9300-24c8e4e1ef16.png">

Also fixed that live videos API errors weren't getting logged