### PR TITLE
Ignoring trailing_whitespace rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ disabled_rules:
   - function_parameter_count
   - unused_closure_parameter
   - nesting
+  - trailing_whitespace
 
 opt_in_rules:
   - redundant_nil_coalescing


### PR DESCRIPTION
The `trailing_whitespace` rule is annoying and has no real benefit to the codebase in general. The Xcode setting that fixes trailing whitespaces has some side-effects I'm not willing to live with.