### PR TITLE
Use the nicer URLError bridging

### DIFF
--- a/WWDC/DownloadManager.swift
+++ b/WWDC/DownloadManager.swift
@@ -514,10 +514,10 @@ extension DownloadManager: URLSessionDownloadDelegate, URLSessionTaskDelegate {
         downloadTasks.removeValue(forKey: originalAbsoluteURLString)
 
         if let error = error {
-            let nsError = error as NSError
-            if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            switch error {
+            case let error as URLError where error.code == URLError.cancelled:
                 NotificationCenter.default.post(name: .DownloadManagerDownloadCancelled, object: originalAbsoluteURLString)
-            } else {
+            default:
                 NotificationCenter.default.post(name: .DownloadManagerDownloadFailed, object: originalAbsoluteURLString, userInfo: ["error": error])
             }
         }


### PR DESCRIPTION
This is a cosmetic code change. I recently learned about (this)[https://github.com/apple/swift-evolution/blob/master/proposals/0112-nserror-bridging.md]. The bridged errors, `URLError, `CocoaError`, `AVError`, others?, are much nicer than bridging to `NSError` and doing domain checking, but they're somewhat undiscoverable because I've been writing Swift for > 3 years and I just learned about them 😂

This can go in whenever is convenient.