### PR TITLE
Hide controls when the mouse exists or app resigns main

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1241,7 +1241,7 @@ public final class PUIPlayerView: NSView {
         guard isPlaying else { return false }
         guard player.status == .readyToPlay else { return false }
         guard let window = window else { return false }
-        guard NSApp.isActive && window.isOnActiveSpace && window.isVisible else { return false }
+        guard window.isOnActiveSpace && window.isVisible else { return false }
 
         guard !timelineView.isEditingAnnotation else { return false }
 

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1354,7 +1354,6 @@ public final class PUIPlayerView: NSView {
         // resigning main in full screen means we're leaving the space
         if windowIsInFullScreen {
             resetMouseIdleTimer(start: false)
-            showControls(animated: false)
         }
     }
 


### PR DESCRIPTION
Fixes two issues with controls staying on screen: 
- When using an external display and watching a full screen stream/video, clicking any other app on the other screen would show the controls. Described in #538 
- When the window is not main, you can hover over the window and the controls will show up (as expected) but won't be hidden when you leave the window. 

Fixes #538 