### PR TITLE
Add Keyboard Shortcuts to Increase/Reduce Playback Speed

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -994,13 +994,20 @@ public final class PUIPlayerView: NSView {
     }
     
     public func reduceSpeed() {
-        for speed in PUIPlaybackSpeed.all {
-            
+        guard let speedIndex = PUIPlaybackSpeed.all.firstIndex(of: playbackSpeed) else { return }
+        if speedIndex > 0 {
+            playbackSpeed = PUIPlaybackSpeed.all[speedIndex - 1]
+            showControls(animated: true)
+            resetMouseIdleTimer()
         }
     }
     
     public func increaseSpeed() {
-        for speed in PUIPlaybackSpeed.all {
+        guard let speedIndex = PUIPlaybackSpeed.all.firstIndex(of: playbackSpeed) else { return }
+        if speedIndex < PUIPlaybackSpeed.all.count - 1 {
+            playbackSpeed = PUIPlaybackSpeed.all[speedIndex + 1]
+            showControls(animated: true)
+            resetMouseIdleTimer()
         }
     }
 

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -992,6 +992,17 @@ public final class PUIPlayerView: NSView {
             playbackSpeed = playbackSpeed.next
         }
     }
+    
+    public func reduceSpeed() {
+        for speed in PUIPlaybackSpeed.all {
+            
+        }
+    }
+    
+    public func increaseSpeed() {
+        for speed in PUIPlaybackSpeed.all {
+        }
+    }
 
     @IBAction public func addAnnotation(_ sender: NSView?) {
         guard let player = player else { return }
@@ -1129,6 +1140,8 @@ public final class PUIPlayerView: NSView {
         case spaceBar = 49
         case leftArrow = 123
         case rightArrow = 124
+        case minus = 27
+        case plus = 24
     }
 
     private func startMonitoringKeyEvents() {
@@ -1158,6 +1171,14 @@ public final class PUIPlayerView: NSView {
 
             case .rightArrow:
                 self.goForwardInTime(nil)
+                return nil
+ 
+            case .minus:
+                self.reduceSpeed()
+                return nil
+ 
+            case .plus:
+                self.increaseSpeed()
                 return nil
             }
         }


### PR DESCRIPTION
Based this PR off of https://github.com/insidegui/WWDC/pull/451

Adding keyboard shortcuts to increase or reduce playback using mius (-) and plus (+) keys. Mimicking VLC's usage of command plus/minus. Open to other keyboard shortcut suggestions.

The implementation is a little hamfisted, but gets the job done. Would love any feedback or suggestions on how I can make this fit better into the project.  I also saw that you may be changing to allow users to enter their own speed preferences, so this may be irrelevant. I find this very useful as I often increase speed on Youtube using chrome extensions that have shortcuts to increase/decrease/normalize playback speed.  