### PR TITLE
Disabled player view scrim by default

### DIFF
--- a/PlayerUI/Views/PUIScrimContainerView.swift
+++ b/PlayerUI/Views/PUIScrimContainerView.swift
@@ -10,14 +10,22 @@ import Cocoa
 
 final class PUIScrimContainerView: NSView {
 
+    var isScrimEnabled: Bool {
+        return UserDefaults.standard.bool(forKey: "PUIScrimEnabled")
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
 
         wantsLayer = true
-        layer?.backgroundColor = NSColor(calibratedWhite: 0, alpha: 0.2).cgColor
+
+        if isScrimEnabled {
+            layer?.backgroundColor = NSColor(calibratedWhite: 0, alpha: 0.2).cgColor
+
+            layer?.addSublayer(topScrimLayer)
+        }
 
         layer?.addSublayer(bottomScrimLayer)
-        layer?.addSublayer(topScrimLayer)
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
This has been the source of complaints for a long time that when hovering over the player the entire image would be dimmed. This fixes that by disabling the full player scrim, leaving just a slight gradient behind the controls.

The previous behavior can be restored with `defaults write io.wwdc.app PUIScrimEnabled YES` for those who prefer that.