### PR TITLE
Fix issue where not all related sessions were displayed

### DIFF
--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -149,9 +149,9 @@ final class SessionViewModel {
     }()
 
     lazy var rxRelatedSessions: Observable<Results<RelatedResource>> = {
-        // Related must either have a video or occur in the future
+        // Return sessions with videos, or any session that hasn't yet occurred
         let predicateFormat = "type == %@ AND (ANY session.assets.rawAssetType == %@ OR ANY session.instances.startTime >= %@)"
-        let relatedPredicate = NSPredicate(format: predicateFormat, RelatedResourceType.session.rawValue, SessionAssetType.sdVideo.rawValue, today() as NSDate)
+        let relatedPredicate = NSPredicate(format: predicateFormat, RelatedResourceType.session.rawValue, SessionAssetType.streamingVideo.rawValue, today() as NSDate)
         let validRelatedSessions = self.session.related.filter(relatedPredicate)
 
         return Observable.collection(from: validRelatedSessions)

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -149,8 +149,9 @@ final class SessionViewModel {
     }()
 
     lazy var rxRelatedSessions: Observable<Results<RelatedResource>> = {
-        let predicateFormat = "type == %@ AND (ANY session.instances.sessionType == %d OR ANY session.instances.startTime >= %@)"
-        let relatedPredicate = NSPredicate(format: predicateFormat, RelatedResourceType.session.rawValue, SessionInstanceType.session.rawValue, today() as NSDate)
+        // Related must either have a video or occur in the future
+        let predicateFormat = "type == %@ AND (ANY session.assets.rawAssetType == %@ OR ANY session.instances.startTime >= %@)"
+        let relatedPredicate = NSPredicate(format: predicateFormat, RelatedResourceType.session.rawValue, SessionAssetType.sdVideo.rawValue, today() as NSDate)
         let validRelatedSessions = self.session.related.filter(relatedPredicate)
 
         return Observable.collection(from: validRelatedSessions)


### PR DESCRIPTION
For some reason I noticed that the "related sessions" displayed on the official website were different to those we were displaying. We still have all the same data, the difference is in how we filter it. I think SessionInstances only occur for the current year, so related sessions from previous years were being hidden?

I'm not sure if this is a perfect fix. The existing logic seemed to be angling for "any video, or any event that is scheduled to happen in future", which I've tried to achieve a different way.

Given (Only 4 of these are videos):
```
        {
            "id": "wwdc2018-225",
            ...
            "related": {
                "activities": [
                    "wwdc2019-215",
                    "wwdc2018-2290",
                    "wwdc2018-2400",
                    "wwdc2017-223",
                    "wwdc2016-219",
                    "wwdc2015-225",
                    "wwdc2014-232"
                ]
            }
        }
```

Before:
<img width="1282" alt="Screenshot 2019-07-13 at 17 32 54" src="https://user-images.githubusercontent.com/11646957/61174246-9f219880-a595-11e9-85a4-686640627526.png">

After:
<img width="1280" alt="Screenshot 2019-07-13 at 17 32 36" src="https://user-images.githubusercontent.com/11646957/61174247-a34db600-a595-11e9-857e-11aec2b0fce3.png">

These now match the four videos highlighted on the website. 🎉 