### PR TITLE
Add JKL playback controls shortcuts

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1171,15 +1171,15 @@ public final class PUIPlayerView: NSView {
             guard !self.timelineView.isEditingAnnotation else { return event }
 
             switch command {
-            case .spaceBar:
+            case .spaceBar, .k:
                 self.togglePlaying(nil)
                 return nil
 
-            case .leftArrow:
+            case .leftArrow, .j:
                 self.goBackInTime(nil)
                 return nil
 
-            case .rightArrow:
+            case .rightArrow, .l:
                 self.goForwardInTime(nil)
                 return nil
  

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1149,6 +1149,9 @@ public final class PUIPlayerView: NSView {
         case rightArrow = 124
         case minus = 27
         case plus = 24
+        case j = 38
+        case k = 40
+        case l = 37
     }
 
     private func startMonitoringKeyEvents() {


### PR DESCRIPTION
# Introduction
JKL playback controls shortcuts are pretty common in video-related software like Quicktime, Final Cut Pro X, YouTube, etc.

Currently, the behavior for QuickTime and Final Cut Pro are very similar to this:
[![](https://support.apple.com/library/APPLE/APPLECARE_ALLGEOS/Product_Help/en_US/PUBLIC_USERS/133280/L0600_JKLKeys_2x.png)](https://support.apple.com/kb/PH12779)

As a video player, and not a video editing software, YouTube has a different, and simpler, approach:
<img width="501" alt="Screen Shot 2019-09-12 at 16 40 38" src="https://user-images.githubusercontent.com/2053643/64815493-149ceb80-d57c-11e9-80a5-78b89fc7ed30.png">

I use this so often that when I tapped the keys and this didn't work out of the box I thought my 2018 MacBook Pro keyboard had more failing keys lol

Last but not least, I love these shortcuts so I added this, maybe someone else can love it too.

# Implementation
Since the WWDC app is a video player, and not a video editing software, I'd say the YouTube's approach makes more sense here, so I propose to add the following shortcuts to the player:
`J` - Go back N seconds
`K` - Play/Pause
`L` - Go forward N seconds

> `N` is the number of seconds configured by the user, which currently the possible values are 15 or 30