### PR TITLE
Fix Ctrl-Click on session list row

### DIFF
--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -363,7 +363,6 @@ class SessionsTableViewController: NSViewController, NSMenuItemValidation {
         v.floatsGroupRows = true
         v.gridStyleMask = .solidHorizontalGridLineMask
         v.gridColor = .darkGridColor
-        v.selectionHighlightStyle = .none // see WWDCTableRowView
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "session"))
         v.addTableColumn(column)


### PR DESCRIPTION
I removed this line of code because it breaks Ctrl+Click action that calls context menu.
Also this fixes issue with bad row selection color. Row selection color is very light. Text color merges with background color.