### PR TITLE
Revert cell selection drawing behavior and restore ctrl+click

### DIFF
--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -363,7 +363,6 @@ class SessionsTableViewController: NSViewController, NSMenuItemValidation {
         v.floatsGroupRows = true
         v.gridStyleMask = .solidHorizontalGridLineMask
         v.gridColor = .darkGridColor
-        v.selectionHighlightStyle = .none // see WWDCTableRowView
 
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(rawValue: "session"))
         v.addTableColumn(column)

--- a/WWDC/WWDCTableRowView.swift
+++ b/WWDC/WWDCTableRowView.swift
@@ -10,58 +10,28 @@ import Cocoa
 
 class WWDCTableRowView: NSTableRowView {
 
-    override var wantsUpdateLayer: Bool {
-        return true
-    }
-
-    override var layerContentsRedrawPolicy: NSView.LayerContentsRedrawPolicy {
-        get { return .onSetNeedsDisplay }
-        // swiftlint:disable:next unused_setter_value
-        set { }
-    }
-
-    override func makeBackingLayer() -> CALayer {
-        let layer = super.makeBackingLayer()
-
-        updateBackgroundColorToMatchState(for: layer)
-
-        return layer
-    }
-
     override var isGroupRowStyle: Bool {
         didSet {
-            layer.map { updateBackgroundColorToMatchState(for: $0) }
+            setNeedsDisplay(bounds)
         }
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
-        self.layer?.backgroundColor = nil
-    }
-
-    override var isSelected: Bool {
-        didSet {
-            layer.map { updateBackgroundColorToMatchState(for: $0) }
-        }
-    }
-
-    override func updateLayer() {
-        // From `wantsUpdateLayer`:
-        // >> If you override this property to be true,
-        // >> you must also override the updateLayer() method of your view and
-        // >> use it to make the changes to your layer.
-        // From `updateLayer`:
-        // >> Your implementation of this method should not call super.
-    }
-
-    private func updateBackgroundColorToMatchState(for layer: CALayer) {
-        if isGroupRowStyle {
-            layer.backgroundColor = NSColor.sectionHeaderBackground.cgColor
-        } else if isSelected {
-            layer.backgroundColor = NSColor.selection.cgColor
+    override func drawSelection(in dirtyRect: NSRect) {
+        if window?.isKeyWindow == false || NSApp.isActive == false {
+            super.drawSelection(in: dirtyRect)
         } else {
-            layer.backgroundColor = nil
+            NSColor.selection.set()
+            dirtyRect.fill()
         }
     }
+
+    override func drawBackground(in dirtyRect: NSRect) {
+        if isGroupRowStyle {
+            NSColor.sectionHeaderBackground.set()
+            dirtyRect.fill()
+        } else {
+            super.drawBackground(in: dirtyRect)
+        }
+    }
+
 }


### PR DESCRIPTION
• Reverts selection drawing to the way it used to be
• Restores ctrl+click functionality that I broke
• Also for some ✨ , I added a conditional for when the window is not key/app is not active for the selection color to go muted like the default NSTableView behavior

Basically, I broke this behavior a while ago while attempting to track down a drawing performance issue. The changes I made were not actually the fix, but I never reverted them.

Supersedes #585 

![NewSelection](https://user-images.githubusercontent.com/8225090/69920868-95200980-1452-11ea-909e-10feb14632cd.gif)
