### PR TITLE
Fix popover positioning on Catalina

### DIFF
--- a/WWDC/DownloadsStatusViewController.swift
+++ b/WWDC/DownloadsStatusViewController.swift
@@ -46,7 +46,6 @@ class DownloadsStatusViewController: NSViewController {
 
         view.addSubview(statusButton)
         statusButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40).isActive = true
-        statusButton.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 1, constant: 0).isActive = true
         statusButton.widthAnchor.constraint(equalTo: view.heightAnchor, multiplier: 1, constant: 0).isActive = true
         statusButton.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
 


### PR DESCRIPTION
<img width="420" alt="Screen Shot 2020-02-21 at 9 51 33 AM" src="https://user-images.githubusercontent.com/8225090/75044651-04c0f600-5490-11ea-830d-8a40a502c47c.png">
<img width="409" alt="Screen Shot 2020-02-21 at 9 51 10 AM" src="https://user-images.githubusercontent.com/8225090/75044653-04c0f600-5490-11ea-9d8b-279ba148da25.png">

I hope this fix will work on older macOS versions, too. I'm not sure why I had that height constraint in there to begin with.