### PR TITLE
Limit downloads folder recursion, add warnings (Closes #584)

### DIFF
--- a/WWDC/DownloadManager.swift
+++ b/WWDC/DownloadManager.swift
@@ -450,7 +450,15 @@ final class DownloadManager: NSObject {
     /// re-enumerated. This function has signifcant side effects.
     fileprivate func updateDownloadedFlagsByEnumeratingFilesAtPath(_ path: String) {
         guard let enumerator = FileManager.default.enumerator(atPath: path) else { return }
-        guard let files = enumerator.allObjects as? [String] else { return }
+
+        var files: [String] = []
+
+        while let path = enumerator.nextObject() as? String {
+            if enumerator.level > 2 { enumerator.skipDescendants() }
+            files.append(path)
+        }
+
+        guard !files.isEmpty else { return }
 
         storage.updateDownloadedFlag(true, forAssetsAtPaths: files)
 

--- a/WWDC/GeneralPreferencesViewController.swift
+++ b/WWDC/GeneralPreferencesViewController.swift
@@ -162,7 +162,7 @@ class GeneralPreferencesViewController: NSViewController {
         downloadsFolderLabel.stringValue = url.path
     }
 
-    private lazy var dangeoursLocalStoragePaths: [String] = {
+    private lazy var dangerousLocalStoragePaths: [String] = {
         [
             NSHomeDirectory(),
             "/"
@@ -179,7 +179,7 @@ class GeneralPreferencesViewController: NSViewController {
     }
 
     private func validateDownloadsFolder(_ url: URL) -> Bool {
-        guard !dangeoursLocalStoragePaths.contains(url.path) else {
+        guard !dangerousLocalStoragePaths(url.path) else {
             showStoragePathError(with: "This folder can't be used to store downloaded videos, please choose another one. Downloaded videos can't be stored in the root of your home directory or in the root of the filesystem.")
             return false
         }


### PR DESCRIPTION
This addresses the issue that caused hangs when a downloads folder had a deeply nested hierarchy of files.

I've implemented both the suggestion by @allenhumphreys to limit recursion, but I've also added some warnings to the UI when changing folders.

If the user tries to set the downloads folder to a folder that has more than 3 files inside of it (3 was randomly chosen as a threshold for "is this folder empty enough?"), there will be a warning:
<img width="538" alt="Screen Shot 2020-05-27 at 18 02 39" src="https://user-images.githubusercontent.com/67184/83072570-61aaea00-a045-11ea-8dbb-663abfa71744.png">

If the user tries to do something *really stupid*, such as using the home directory or `/` as the downloads folder, the app will prevent it:
<img width="532" alt="Screen Shot 2020-05-27 at 18 06 58" src="https://user-images.githubusercontent.com/67184/83072606-71c2c980-a045-11ea-965f-7c416b7d792b.png">
