### PR TITLE
Fixes layout bug in transcript cell

### DIFF
--- a/WWDC/TranscriptTableCellView.swift
+++ b/WWDC/TranscriptTableCellView.swift
@@ -36,6 +36,8 @@ class TranscriptTableCellView: NSTableCellView {
         l.textColor = .primaryText
         l.cell?.backgroundStyle = .dark
         l.lineBreakMode = .byTruncatingTail
+        l.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        l.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         return l
     }()


### PR DESCRIPTION
This fixes a bug caused by having wrong hugging/compression priorities set for the time vs. body label in the transcript cell. It became more apparent after migrating to Apple's transcripts since they tend to have shorter lines.