### PR TITLE
Fixes a crash when updating session progress

### DIFF
--- a/WWDC/PlaybackViewModel.swift
+++ b/WWDC/PlaybackViewModel.swift
@@ -118,7 +118,7 @@ final class PlaybackViewModel {
             player.seek(to: CMTimeMakeWithSeconds(Float64(session.currentPosition()), preferredTimescale: 9000))
         }
 
-        timeObserver = player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(5, preferredTimescale: 9000), queue: DispatchQueue.main) { [weak self] currentTime in
+        timeObserver = player.addPeriodicTimeObserver(forInterval: CMTimeMakeWithSeconds(10, preferredTimescale: 9000), queue: DispatchQueue.main) { [weak self] currentTime in
             guard let self = self else { return }
 
             guard let duration = self.player.currentItem?.asset.durationIfLoaded else { return }


### PR DESCRIPTION
Something about updating the session progress on the main realm instance was causing a timing-related crash that seemed to occur when session playback started very early on the lifecycle of the app. Moving these updates to a serial background queue fixed the crash.