### PR TITLE
Simple fix for event hero layout changes

### DIFF
--- a/ConfCore/EventHero.swift
+++ b/ConfCore/EventHero.swift
@@ -9,7 +9,7 @@
 import Foundation
 import RealmSwift
 
-/// Depiction of a current event for which the schedule is not available (a "coming soon" type page)
+/// Depiction of a current event.
 public class EventHero: Object, Codable {
 
     @objc public dynamic var identifier = ""
@@ -18,9 +18,28 @@ public class EventHero: Object, Codable {
     @objc public dynamic var body = ""
     @objc public dynamic var bodyColor: String?
     @objc public dynamic var backgroundImage = ""
+    public let textComponents = List<String>()
 
     public override class func primaryKey() -> String? {
         return "identifier"
+    }
+
+    public convenience required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.init()
+
+        self.identifier = try container.decode(String.self, forKey: .identifier)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.body = try container.decode(String.self, forKey: .body)
+        self.backgroundImage = try container.decode(String.self, forKey: .backgroundImage)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.titleColor = try container.decodeIfPresent(String.self, forKey: .titleColor)
+        self.bodyColor = try container.decodeIfPresent(String.self, forKey: .bodyColor)
+        self.backgroundImage = try container.decode(String.self, forKey: .backgroundImage)
+
+        let components = try container.decodeIfPresent([String].self, forKey: .textComponents)
+        components?.forEach { textComponents.append($0) }
     }
 
 }

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC_iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC_iCloud.xcscheme
@@ -107,7 +107,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-transcripts"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--prefs"

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Constants {
 
-    static let coreSchemaVersion: UInt64 = 54
+    static let coreSchemaVersion: UInt64 = 55
 
     static let thumbnailHeight: CGFloat = 150
 


### PR DESCRIPTION
Since the event hero can have more lines of text, I decided to parse those from the backend and display them all. The text scrolls if it's too big to fit on screen. Also added background dimming and shadow for contrast.

<img width="1217" alt="Messages Image(956343600)" src="https://user-images.githubusercontent.com/67184/84416767-08b58700-abeb-11ea-84a3-d5a261e7951c.png">
