### PR TITLE
Allow for longer session summaries by making the text scrollable

### DIFF
--- a/WWDC/DownloadManager.swift
+++ b/WWDC/DownloadManager.swift
@@ -144,6 +144,10 @@ final class DownloadManager: NSObject {
         return isDownloading(url)
     }
 
+    func isDownloadable(_ session: Session) -> Bool {
+        return session.asset(ofType: DownloadManager.downloadQuality) != nil
+    }
+
     func downloadedFileURL(for session: Session) -> URL? {
         guard let asset = session.asset(ofType: DownloadManager.downloadQuality) else { return nil }
 

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -249,6 +249,8 @@ private class SessionDetailsTabContainer: NSView {
 
     var currentView: NSView? {
         didSet {
+            guard oldValue !== currentView else { return }
+
             oldValue?.removeFromSuperview()
 
             if let newView = currentView {

--- a/WWDC/SessionsTableViewController.swift
+++ b/WWDC/SessionsTableViewController.swift
@@ -507,9 +507,11 @@ class SessionsTableViewController: NSViewController, NSMenuItemValidation {
 
         switch menuItem.option {
         case .download:
-            return !DownloadManager.shared.isDownloading(viewModel.session) && !DownloadManager.shared.hasDownloadedVideo(session: viewModel.session)
+            return DownloadManager.shared.isDownloadable(viewModel.session) &&
+                !DownloadManager.shared.isDownloading(viewModel.session) &&
+                !DownloadManager.shared.hasDownloadedVideo(session: viewModel.session)
         case .cancelDownload:
-            return DownloadManager.shared.isDownloading(viewModel.session)
+            return DownloadManager.shared.isDownloadable(viewModel.session) && DownloadManager.shared.isDownloading(viewModel.session)
         case .revealInFinder:
             return DownloadManager.shared.hasDownloadedVideo(session: viewModel.session)
         default: ()


### PR DESCRIPTION
(also fixes the context menu incorrectly suggesting you can download a session)