### PR TITLE
Allowing feeds to be missing in the config response

### DIFF
--- a/Packages/ConfCore/ConfCore/ConfigResponse.swift
+++ b/Packages/ConfCore/ConfCore/ConfigResponse.swift
@@ -19,13 +19,13 @@ public struct ConfigResponse: Hashable, Codable {
         }
 
         public let contents: Feed
-        public let articles: Feed
-        public let layout: Feed
-        public let maps: Feed
-        public let liveVideos: Feed
-        public let discover: Feed
-        public let event: Feed
-        public let transcripts: Feed
+        public let articles: Feed?
+        public let layout: Feed?
+        public let maps: Feed?
+        public let liveVideos: Feed?
+        public let discover: Feed?
+        public let event: Feed?
+        public let transcripts: Feed?
     }
 
     /// Maps from language ID (such as "en", "zho", etc) to feed manifests.

--- a/Packages/ConfCore/ConfCore/TranscriptIndexingClient.swift
+++ b/Packages/ConfCore/ConfCore/TranscriptIndexingClient.swift
@@ -104,6 +104,11 @@ final class TranscriptIndexingClient: NSObject, TranscriptIndexingClientProtocol
             os_log("No feeds found for currently set language (%@) or fallback language (%@)", log: self.log, type: .error, transcriptLanguage, ConfigResponse.fallbackFeedLanguage)
             return
         }
+        
+        guard let transcriptsFeedURL = feeds.transcripts?.url else {
+            os_log("Manifest doesn't have a URL for the transcripts feed", log: self.log, type: .error)
+            return
+        }
 
         guard let storageURL = storage.realmConfig.fileURL else { return }
 
@@ -111,7 +116,7 @@ final class TranscriptIndexingClient: NSObject, TranscriptIndexingClientProtocol
         migratedTranscriptsToNativeVersion = true
 
         transcriptIndexingService?.indexTranscriptsIfNeeded(
-            manifestURL: feeds.transcripts.url,
+            manifestURL: transcriptsFeedURL,
             ignoringCache: ignoreCache,
             storageURL: storageURL,
             schemaVersion: storage.realmConfig.schemaVersion


### PR DESCRIPTION
Not all feeds are available all the time, this makes it less fragile.