### PR TITLE
Updated API endpoint for 2021

### DIFF
--- a/Packages/ConfCore/ConfCore/Environment.swift
+++ b/Packages/ConfCore/ConfCore/Environment.swift
@@ -113,7 +113,7 @@ extension Environment {
                                          liveVideosPath: "/videos_live.json",
                                          featuredSectionsPath: "/_featured.json")
 
-    public static let production = Environment(baseURL: "https://api2020.wwdc.io",
+    public static let production = Environment(baseURL: "https://api2021.wwdc.io",
                                                cocoaHubBaseURL: Self.defaultCocoaHubBaseURL,
                                                configPath: "/config.json",
                                                sessionsPath: "/contents.json",

--- a/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC_iCloud.xcscheme
+++ b/WWDC.xcodeproj/xcshareddata/xcschemes/WWDC_iCloud.xcscheme
@@ -98,7 +98,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-WWDCEnvironmentBaseURL &quot;https://calm-block-8cce.rambo.workers.dev&quot;"
+            argument = "-WWDCEnvironmentBaseURL &quot;http://localhost:7777&quot;"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument


### PR DESCRIPTION
The API proxy is now hosted on MacStadium, so I gave it a new base URL for this year.