### PR TITLE
Implemented data reset option

### DIFF
--- a/WWDC/AppDelegate.swift
+++ b/WWDC/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
     }
-    
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         NSAppleEventManager.shared().setEventHandler(self, andSelector: #selector(handleURLEvent(_:replyEvent:)), forEventClass: UInt32(kInternetEventClass), andEventID: UInt32(kAEGetURL))
 
@@ -102,9 +102,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func handleBootstrapError(_ error: Boot.BootstrapError) {
-        if error.code == .unusableStorage {
+        switch error.code {
+        case .unusableStorage:
             handleStorageError(error)
-        } else {
+        case .dataReset:
+            break
+        default:
             let alert = NSAlert()
             alert.messageText = "Failed to start"
             alert.informativeText = error.localizedDescription
@@ -139,6 +142,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var migrationSplashShown = false
 
     private func showMigrationSplashScreen() {
+        /// Prevent migration splash screen from showing up during other types of launch alerts,
+        /// such as the data reset confirmation when holding down the Option key.
+        guard NSApp.modalWindow == nil else { return }
+
         migrationSplashShown = true
         slowMigrationController.showWindow(self)
     }


### PR DESCRIPTION
When holding the Option key during app launch, it will offer to reset the local database. Confirming the reset deletes the application support directory with the local database and caches. This is an escape hatch in case existing local data is causing the app to misbehave.


https://github.com/insidegui/WWDC/assets/67184/5e96224e-59d7-4d5c-83d6-a75307da4509

