### PR TITLE
Fixed crash in ImageDownloadCenter caused by RemoteImage

### DIFF
--- a/WWDC/RemoteImage.swift
+++ b/WWDC/RemoteImage.swift
@@ -28,6 +28,7 @@ struct RemoteImage<Content: View, Placeholder: View>: View {
         }
     }
 
+    @MainActor
     private func load() async -> NSImage? {
         await withCheckedContinuation { continuation in
             switch size {


### PR DESCRIPTION
The app would randomly crash on launch because `RemoteImage` was using `ImageDownloadCenter` from a concurrent queue due to its `load()` method being `async` but not bound to the main actor.