### PR TITLE
Improve Explore tab experience when migrating from previous version, fix dangling "Topics" track

### DIFF
--- a/Packages/ConfCore/ConfCore/StorageMigrator.swift
+++ b/Packages/ConfCore/ConfCore/StorageMigrator.swift
@@ -27,9 +27,10 @@ final class StorageMigrator {
         32: migrateSessionModels,
         34: migrateOldTranscriptModels,
         37: migrateIdentifiersWithoutReplacement,
-        43: migrateTracks,
+        43: resetTracks,
         44: removeInvalidLiveAssets,
-        57: resetFeaturedSections
+        57: resetFeaturedSections,
+        59: resetTracks
     ]
 
     init(migration: Migration, oldVersion: UInt64) {
@@ -162,8 +163,8 @@ final class StorageMigrator {
         }
     }
 
-    private static func migrateTracks(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
-        os_log("migrateTracks", log: log, type: .info)
+    private static func resetTracks(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        os_log("resetTracks", log: log, type: .info)
 
         migration.deleteData(forType: "Track")
     }

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Constants {
 
-    static let coreSchemaVersion: UInt64 = 58
+    static let coreSchemaVersion: UInt64 = 59
 
     static let thumbnailHeight: CGFloat = 150
 

--- a/WWDC/ExploreTabContent.swift
+++ b/WWDC/ExploreTabContent.swift
@@ -72,13 +72,47 @@ extension ExploreTabContent.Item {
             imageURL: URL(string: "https://wwdc.io/images/placeholder.jpg")!
         )
     ]
+    static let placeholderItems2: [ExploreTabContent.Item] = [
+        .init(
+            id: "4",
+            title: "Placeholder Item Regular",
+            subtitle: "Placeholder Description 4",
+            overlayText: "24m",
+            overlaySymbol: "play",
+            imageURL: URL(string: "https://wwdc.io/images/placeholder.jpg")!
+        ),
+        .init(
+            id: "5",
+            title: "Placeholder",
+            subtitle: "Placeholder Item Description 5",
+            overlayText: "37m",
+            overlaySymbol: "play",
+            imageURL: URL(string: "https://wwdc.io/images/placeholder.jpg")!
+        ),
+        .init(
+            id: "6",
+            title: "Placeholder Item Longer Title",
+            subtitle: "Placeholder Item Description 6",
+            overlayText: "37m",
+            overlaySymbol: "play",
+            imageURL: URL(string: "https://wwdc.io/images/placeholder.jpg")!
+        ),
+        .init(
+            id: "7",
+            title: "Placeholder",
+            subtitle: "Item Description 7",
+            overlayText: "35m",
+            overlaySymbol: "play",
+            imageURL: URL(string: "https://wwdc.io/images/placeholder.jpg")!
+        )
+    ]
 }
 
 extension ExploreTabContent {
     static let placeholder: ExploreTabContent = {
         ExploreTabContent(id: "1", sections: [
             Section(id: "placeholder-1", title: "Placeholder Section First", icon: .symbol("app.badge.checkmark"), items: ExploreTabContent.Item.placeholderItems),
-            Section(id: "placeholder-2", title: "Placeholder Section Second Longer Title", icon: .symbol("app.badge.checkmark"), items: ExploreTabContent.Item.placeholderItems),
+            Section(id: "placeholder-2", title: "Placeholder Section Second Longer Title", icon: .symbol("app.badge.checkmark"), items: ExploreTabContent.Item.placeholderItems2),
             Section(id: "placeholder-3", title: "Placeholder Short", icon: .symbol("app.badge.checkmark"), items: ExploreTabContent.Item.placeholderItems)
         ])
     }()

--- a/WWDC/ExploreTabItemView.swift
+++ b/WWDC/ExploreTabItemView.swift
@@ -27,7 +27,13 @@ struct ExploreTabItemView: View {
             item.progress != nil ? .topTrailing : .bottomTrailing
         }
 
-        private var hasOverlay: Bool { item.overlayText != nil || item.overlaySymbol != nil }
+        @Environment(\.redactionReasons)
+        private var redactionReasons
+
+        private var hasOverlay: Bool {
+            guard redactionReasons.isEmpty else { return false }
+            return item.overlayText != nil || item.overlaySymbol != nil
+        }
 
         var body: some View {
             VStack(alignment: .leading, spacing: 8) {

--- a/WWDC/ExploreTabProvider.swift
+++ b/WWDC/ExploreTabProvider.swift
@@ -71,7 +71,7 @@ final class ExploreTabProvider: ObservableObject {
 
     private var disposeBag = DisposeBag()
 
-    private struct SourceData {
+    fileprivate struct SourceData {
         var featuredSections: Results<FeaturedSection>
         var continueWatching: [Session]
         var recentFavorites: [Session]
@@ -101,6 +101,8 @@ final class ExploreTabProvider: ObservableObject {
     }
 
     private func update(with data: SourceData) {
+        guard !data.shouldDisplayPlaceholderUI else { return }
+
         let continueWatchingSection = ExploreTabContent.Section(
             id: "continue-watching",
             title: "Continue Watching",
@@ -291,5 +293,17 @@ extension WWDCFiltersState {
                 text: nil
             )
         )
+    }
+}
+
+private extension ExploreTabProvider.SourceData {
+    /// `true` when all sections except for "Topics" are empty.
+    /// This addresses migration from previous versions without an Explore tab,
+    /// where the local database has topics but no other data relevant to the explore tab.
+    var shouldDisplayPlaceholderUI: Bool {
+        featuredSections.isEmpty
+        && continueWatching.isEmpty
+        && recentFavorites.isEmpty
+        && liveEventSession == nil
     }
 }

--- a/WWDC/ExploreTabRootView.swift
+++ b/WWDC/ExploreTabRootView.swift
@@ -4,15 +4,18 @@ struct ExploreTabRootView: View {
     @EnvironmentObject private var provider: ExploreTabProvider
 
     var body: some View {
-        if let content = provider.content {
-            ExploreTabContentView(content: content, scrollOffset: $provider.scrollOffset)
-                #if DEBUG
-                .contextMenu { Button("Export JSON…", action: content.exportJSON) }
-                #endif
-        } else {
-            ExploreTabContentView(content: .placeholder, scrollOffset: .constant(.zero))
-                .redacted(reason: .placeholder)
+        ZStack {
+            if let content = provider.content {
+                ExploreTabContentView(content: content, scrollOffset: $provider.scrollOffset)
+                    #if DEBUG
+                    .contextMenu { Button("Export JSON…", action: content.exportJSON) }
+                    #endif
+            } else {
+                ExploreTabContentView(content: .placeholder, scrollOffset: .constant(.zero))
+                    .redacted(reason: .placeholder)
+            }
         }
+        .animation(.spring(), value: provider.content?.sections.flatMap(\.items).count)
     }
 
 }


### PR DESCRIPTION
- Improves the placeholder state for the Explore tab
- Ensures the Explore tab doesn't show up with a single "Topics" section with the "Topics" topic 🥴
- Bumps schema version with a migration to delete `Track` objects when updating to 7.4, ensuring the new collection of topics replaces the old one