### PR TITLE
Displaying all content in schedule, removed special handling based on session type

### DIFF
--- a/Packages/ConfCore/ConfCore/SessionInstance.swift
+++ b/Packages/ConfCore/ConfCore/SessionInstance.swift
@@ -9,28 +9,6 @@
 import Cocoa
 import RealmSwift
 
-public enum SessionInstanceType: Int, Decodable {
-    case session, lab, video, getTogether, specialEvent, labByAppointment
-
-    init?(rawSessionType: String) {
-        switch rawSessionType {
-        case "Session":
-            self = .session
-        case "Lab":
-            self = .lab
-        case "Video":
-            self = .video
-        case "Get-Together":
-            self = .getTogether
-        case "Special Event":
-            self = .specialEvent
-        case "Lab by Appointment":
-            self = .labByAppointment
-        default: return nil
-        }
-    }
-}
-
 /// A session instance represents a specific occurence of a session with a location and start/end times
 public class SessionInstance: Object, ConditionallyDecodable {
 
@@ -57,17 +35,7 @@ public class SessionInstance: Object, ConditionallyDecodable {
     /// The raw session type as returned by the API
     @objc public dynamic var rawSessionType = "Session"
 
-    /// Type of session (0 = regular session, 1 = lab, 2 = video-only session)
-    @objc public dynamic var sessionType = 0
-
-    public var type: SessionInstanceType {
-        get {
-            return SessionInstanceType(rawValue: sessionType) ?? .session
-        }
-        set {
-            sessionType = newValue.rawValue
-        }
-    }
+    public var sessionType: String { rawSessionType }
 
     /// The start time
     @objc public dynamic var startTime: Date = .distantPast
@@ -121,19 +89,8 @@ public class SessionInstance: Object, ConditionallyDecodable {
     public static func standardSort(instanceA: SessionInstance, instanceB: SessionInstance) -> Bool {
         guard let sessionA = instanceA.session, let sessionB = instanceB.session else { return false }
 
-        let nA = instanceA.code
-        let nB = instanceB.code
-
         if instanceA.sessionType == instanceB.sessionType {
-            if instanceA.sessionType == SessionInstanceType.session.rawValue {
-                if instanceA.startTime == instanceB.startTime {
-                    return nA < nB
-                } else {
-                    return instanceA.startTime < instanceB.startTime
-                }
-            } else {
-                return Session.standardSort(sessionA: sessionA, sessionB: sessionB)
-            }
+            return Session.standardSort(sessionA: sessionA, sessionB: sessionB)
         } else {
             return instanceA.sessionType < instanceB.sessionType
         }
@@ -144,7 +101,6 @@ public class SessionInstance: Object, ConditionallyDecodable {
 
         number = other.number
         rawSessionType = other.rawSessionType
-        sessionType = other.sessionType
         startTime = other.startTime
         endTime = other.endTime
         roomIdentifier = other.roomIdentifier
@@ -198,7 +154,6 @@ public class SessionInstance: Object, ConditionallyDecodable {
 
             let rawType = try container.decode(String.self, forKey: .type)
             self.rawSessionType = rawType
-            self.sessionType = SessionInstanceType(rawSessionType: rawType)?.rawValue ?? 0
 
             if try container.decodeIfPresent(Bool.self, forKey: .hasLiveStream) == true {
                 self.hasLiveStream = true

--- a/Packages/ConfCore/ConfCore/Storage.swift
+++ b/Packages/ConfCore/ConfCore/Storage.swift
@@ -581,6 +581,13 @@ public final class Storage {
         return realm.objects(Focus.self).sorted(byKeyPath: "name").toArray()
     }
 
+    public var allSessionTypes: [String] {
+        Array(
+            Set(realm.objects(SessionInstance.self).map(\.rawSessionType))
+        )
+        .sorted(by: { $0.localizedStandardCompare($1) == .orderedAscending })
+    }
+
     public var allTracks: [Track] {
         return realm.objects(Track.self).sorted(byKeyPath: "order").toArray()
     }

--- a/Packages/ConfCore/ConfCore/StorageMigrator.swift
+++ b/Packages/ConfCore/ConfCore/StorageMigrator.swift
@@ -30,7 +30,8 @@ final class StorageMigrator {
         43: resetTracks,
         44: removeInvalidLiveAssets,
         57: resetFeaturedSections,
-        59: resetTracks
+        59: resetTracks,
+        60: resetSessionInstances
     ]
 
     init(migration: Migration, oldVersion: UInt64) {
@@ -187,6 +188,10 @@ final class StorageMigrator {
         migration.deleteData(forType: "FeaturedSection")
         migration.deleteData(forType: "FeaturedContent")
         migration.deleteData(forType: "FeaturedAuthor")
+    }
+
+    private static func resetSessionInstances(with migration: Migration, oldVersion: SchemaVersion, log: OSLog) {
+        migration.deleteData(forType: "SessionInstance")
     }
 
 }

--- a/WWDC/Constants.swift
+++ b/WWDC/Constants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Constants {
 
-    static let coreSchemaVersion: UInt64 = 59
+    static let coreSchemaVersion: UInt64 = 60
 
     static let thumbnailHeight: CGFloat = 150
 

--- a/WWDC/SearchCoordinator.swift
+++ b/WWDC/SearchCoordinator.swift
@@ -58,10 +58,7 @@ final class SearchCoordinator {
 
         var scheduleTextualFilter = TextualFilter(identifier: FilterIdentifier.text, value: nil)
 
-        let sessionOption = FilterOption(title: "Sessions", value: "Session")
-        let labOption = sessionOption.negated(with: "Labs and Others")
-
-        let eventOptions = [sessionOption, labOption]
+        let eventOptions = storage.allSessionTypes.map { FilterOption(title: $0, value: $0) }
         var scheduleEventFilter = MultipleChoiceFilter(identifier: FilterIdentifier.event,
                                                        isSubquery: true,
                                                        collectionKey: "instances",

--- a/WWDC/SessionCellView.swift
+++ b/WWDC/SessionCellView.swift
@@ -56,19 +56,6 @@ final class SessionCellView: NSView {
         viewModel.rxIsFavorite.distinctUntilChanged().map({ !$0 }).bind(to: favoritedImageView.rx.isHidden).disposed(by: disposeBag)
         viewModel.rxIsDownloaded.distinctUntilChanged().map({ !$0 }).bind(to: downloadedImageView.rx.isHidden).disposed(by: disposeBag)
 
-        let isSnowFlake = Observable.zip(viewModel.rxIsCurrentlyLive, viewModel.rxIsLab)
-
-        isSnowFlake.map({ !$0.0 && !$0.1 }).bind(to: snowFlakeView.rx.isHidden).disposed(by: disposeBag)
-        isSnowFlake.map({ $0.0 || $0.1 }).bind(to: thumbnailImageView.rx.isHidden).disposed(by: disposeBag)
-
-        isSnowFlake.subscribe(onNext: { [weak self] (isLive: Bool, isLab: Bool) -> Void in
-            if isLive {
-                self?.snowFlakeView.image = #imageLiteral(resourceName: "live-indicator")
-            } else if isLab {
-                self?.snowFlakeView.image = #imageLiteral(resourceName: "lab-indicator")
-            }
-        }).disposed(by: disposeBag)
-
         viewModel.rxImageUrl.distinctUntilChanged({ $0 != $1 }).subscribe(onNext: { [weak self] imageUrl in
             guard let imageUrl = imageUrl else { return }
 
@@ -96,17 +83,6 @@ final class SessionCellView: NSView {
             } else {
                 self?.contextColorView.hasValidProgress = false
                 self?.contextColorView.progress = 0
-            }
-        }).disposed(by: disposeBag)
-
-        viewModel.rxSessionType.distinctUntilChanged().subscribe(onNext: { [weak self] type in
-            guard ![.lab, .session, .labByAppointment].contains(type) else { return }
-
-            switch type {
-            case .getTogether:
-                self?.thumbnailImageView.image = #imageLiteral(resourceName: "get-together")
-            default:
-                self?.thumbnailImageView.image = #imageLiteral(resourceName: "special")
             }
         }).disposed(by: disposeBag)
     }

--- a/WWDC/SessionDetailsViewController.swift
+++ b/WWDC/SessionDetailsViewController.swift
@@ -36,23 +36,6 @@ final class SessionDetailsViewController: WWDCWindowContentViewController {
 
             let shouldHideButtonsBar = transcriptButton.isHidden && bookmarksButton.isHidden
             menuButtonsContainer.isHidden = shouldHideButtonsBar
-
-            let instance = viewModel.sessionInstance
-            let type = instance.type
-
-            let sessionHasNoVideo = [.lab, .getTogether, .labByAppointment].contains(type) && !(instance.isCurrentlyLive == true)
-
-            shelfController.view.isHidden = sessionHasNoVideo
-
-            // It's worth noting that this condition will always be true since the view
-            // gets loaded when add to the split view controller
-            if isViewLoaded {
-                // Connect stack view (bottom half of screen), to the top of the view
-                // or to the bottom of the video, if it's present
-                shelfBottomConstraint.isActive = !sessionHasNoVideo
-                informationStackViewTopConstraint.isActive = sessionHasNoVideo
-                informationStackViewBottomConstraint.isActive = !sessionHasNoVideo
-            }
         }
     }
 

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -208,25 +208,32 @@ final class SessionViewModel {
     }
 
     static func context(for session: Session, instance: SessionInstance? = nil) -> String {
-        if let instance = instance {
-            var result = timeFormatter.string(from: instance.startTime) + " - " + timeFormatter.string(from: instance.endTime)
+        var components = [String]()
 
-            result += " · " + instance.roomName
+        if let instance {
+            components = [timeFormatter.string(from: instance.startTime)]
 
-            return result
+            /// The end time is only relevant when the instance has a live component,
+            /// and let's also ensure the start and end times are not the same just in case.
+            if instance.hasLiveStream, instance.startTime != instance.endTime {
+                components.append(timeFormatter.string(from: instance.endTime))
+            }
+        } else {
+            components = []
+        }
+
+        /// Display either track or focuses, prioritizing track, since both won't fit.
+        if let trackName = session.track.first?.name {
+            components.append(trackName)
         } else {
             let focusesArray = session.focuses.toArray()
-
-            let focuses = SessionViewModel.focusesDescription(from: focusesArray, collapse: true)
-
-            var result = session.track.first?.name ?? ""
-
-            if focusesArray.count > 0 {
-                result = "\(focuses) · " + result
+            if !focusesArray.isEmpty {
+                let focuses = SessionViewModel.focusesDescription(from: focusesArray, collapse: true)
+                components.append(focuses)
             }
-
-            return result
         }
+
+        return components.joined(separator: " · ")
     }
 
     static func footer(for session: Session, at event: ConfCore.Event?) -> String {

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -87,10 +87,6 @@ final class SessionViewModel {
         return rxSession.map { SessionViewModel.footer(for: $0, at: $0.event.first) }
     }()
 
-    lazy var rxSessionType: Observable<SessionInstanceType> = {
-        return rxSession.map { $0.instances.first?.type }.ignoreNil()
-    }()
-
     lazy var rxColor: Observable<NSColor> = {
         return rxSession.map { SessionViewModel.trackColor(for: $0) }.ignoreNil()
     }()
@@ -121,14 +117,6 @@ final class SessionViewModel {
         }
 
         return rxSessionInstance.map { $0.isCurrentlyLive }
-    }()
-
-    lazy var rxIsLab: Observable<Bool> = {
-        guard self.sessionInstance.realm != nil else {
-            return Observable.just(false)
-        }
-
-        return rxSessionInstance.map { [.lab, .labByAppointment].contains($0.type) }
     }()
 
     lazy var rxPlayableContent: Observable<Results<SessionAsset>> = {
@@ -266,12 +254,6 @@ final class SessionViewModel {
     }
 
     static func imageUrl(for session: Session) -> URL? {
-        if let instance = session.instances.first {
-            guard [.session, .lab, .labByAppointment].contains(instance.type) else {
-                return nil
-            }
-        }
-
         let imageAsset = session.asset(ofType: .image)
 
         guard let thumbnail = imageAsset?.remoteURL, let thumbnailUrl = URL(string: thumbnail) else { return nil }


### PR DESCRIPTION
We were relying on the content's `type` property for a lot of things with hardcoded types in the app, but Apple hasn't been using `type` as an enum for a good while.

- Changed `SessionInstance` parsing to use `originalPublishingDate` as `startTime` when the content doesn't have `hasLiveStream == true`, that way the schedule tab will display when the video will be published
- Removed hardcoded handling for labs and other special event types and associated special handling for images / shelf since those all have proper image assets now
- Showing all available session types in the filter options for the Schedule tab
- Tweaked table cells in Schedule tab so that they only show the start and end time for sessions with a live component; for other types of events it only shows the start time; also no longer showing room name (lol)

NOTE: I believe there's a lot more that can be removed from the app with the removal of this special handling for different session types, but I chose to keep this PR as small as possible

NOTE 2: there's a bit of special handling on the backend because `Article` and `Collection` are also session types from Apple's API, but we don't support those, so our proxy is filtering them out

NOTE 3: there's a significant migration upon running this version because it will delete all current `SessionInstance` objects; there's no user data associated with that object so it should be fine (famous last words), but because of that the Schedule tab might be empty for several seconds while content is fetched and indexed (we definitely need to move away from Realm)