### PR TITLE
Implement keyboard localization support for player key commands

### DIFF
--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1140,15 +1140,37 @@ public final class PUIPlayerView: NSView {
 
     private var keyDownEventMonitor: Any?
 
-    private enum KeyCommands: UInt16 {
-        case spaceBar = 49
-        case leftArrow = 123
-        case rightArrow = 124
-        case minus = 27
-        case plus = 24
-        case j = 38
-        case k = 40
-        case l = 37
+    private enum KeyCommands {
+        case spaceBar
+        case leftArrow
+        case rightArrow
+        case minus
+        case plus
+        case j
+        case k
+        case l
+
+        static func fromEvent(_ event: NSEvent) -> KeyCommands? {
+            switch event.keyCode {
+            case 123: return .leftArrow
+            case 124: return .rightArrow
+            default: break
+            }
+            
+            guard let character = event.charactersIgnoringModifiers else {
+                return nil
+            }
+            
+            switch character {
+            case " ": return .spaceBar
+            case "-": return .minus
+            case "+": return .plus
+            case "j": return .j
+            case "k": return .k
+            case "l": return .l
+            default: return nil
+            }
+        }
     }
 
     public var isEnabled = true {
@@ -1165,8 +1187,8 @@ public final class PUIPlayerView: NSView {
 
         keyDownEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [unowned self] event in
             guard self.isEnabled else { return event }
-
-            guard let command = KeyCommands(rawValue: event.keyCode) else {
+            
+            guard let command = KeyCommands.fromEvent(event) else {
                 return event
             }
 


### PR DESCRIPTION
The changes enable consistent keyboard shortcuts for media player commands across different keyboard layouts irregardless of the localization. This is achieved by identifying commands based on the character output of keys instead of their key codes which may vary. Due to the non-textual nature of the arrow keys their input remains to be identified by their keycodes.

Example:
The current mapping for `minus` and `plus` is set to the keycodes `27` and `24`. 
This is not applicable to all keyboard layouts. For example, German localized ones use `44` and `30` respectively. 
The proposed changes should solve this. 

Thank you in advanced for reviewing and thank you for the handy app 👍
