### PR TITLE
Optimize schedule grouping to avoid excessive CPU and memory usage on start up

### DIFF
--- a/Packages/ConfCore/ConfCore/Session.swift
+++ b/Packages/ConfCore/ConfCore/Session.swift
@@ -135,31 +135,38 @@ public class Session: Object, Decodable {
         self.assets.append(objectsIn: assets)
 
         other.related.forEach { newRelated in
-            let effectiveRelated: RelatedResource
-
-            if let existingResource = realm.object(ofType: RelatedResource.self, forPrimaryKey: newRelated.identifier) {
-                effectiveRelated = existingResource
-            } else {
-                effectiveRelated = newRelated
-            }
-
-            guard !related.contains(where: { $0.identifier == effectiveRelated.identifier }) else { return }
-            related.append(effectiveRelated)
+            realm.add(newRelated, update: .all)
+//            let effectiveRelated: RelatedResource
+//
+//            if let existingResource = realm.object(ofType: RelatedResource.self, forPrimaryKey: newRelated.identifier) {
+//                effectiveRelated = existingResource
+//            } else {
+//                effectiveRelated = newRelated
+//            }
+//
+//            guard !related.contains(where: { $0.identifier == effectiveRelated.identifier }) else { return }
+//            related.append(effectiveRelated)
         }
+        related.removeAll()
+        related.append(objectsIn: other.related)
 
         other.focuses.forEach { newFocus in
-            let effectiveFocus: Focus
-
-            if let existingFocus = realm.object(ofType: Focus.self, forPrimaryKey: newFocus.name) {
-                effectiveFocus = existingFocus
-            } else {
-                effectiveFocus = newFocus
-            }
-
-            guard !focuses.contains(where: { $0.name == effectiveFocus.name }) else { return }
-
-            focuses.append(effectiveFocus)
+            realm.add(newFocus, update: .all)
+//            let effectiveFocus: Focus
+//
+//            if let existingFocus = realm.object(ofType: Focus.self, forPrimaryKey: newFocus.name) {
+//                effectiveFocus = existingFocus
+//            } else {
+//                effectiveFocus = newFocus
+//            }
+//
+//            guard !focuses.contains(where: { $0.name == effectiveFocus.name }) else { return }
+//
+//            focuses.append(effectiveFocus)
         }
+
+        focuses.removeAll()
+        focuses.append(objectsIn: other.focuses)
     }
 
     // MARK: - Decodable

--- a/Packages/ConfCore/ConfCore/SessionInstance.swift
+++ b/Packages/ConfCore/ConfCore/SessionInstance.swift
@@ -109,10 +109,14 @@ public class SessionInstance: Object, ConditionallyDecodable {
         eventIdentifier = other.eventIdentifier
         calendarEventIdentifier = other.calendarEventIdentifier
 
+        // This requires a ton of work because there are so many session instances
+        // And we
         if let otherSession = other.session, let session = session {
             session.merge(with: otherSession, in: realm)
         }
 
+        // If we collected all the keywords up front and stored them, it'd be faster than
+        // querying against individual sessions' keywords because you end up duplicating a lot of work
         let otherKeywords = other.keywords.map { newKeyword -> (Keyword) in
             if newKeyword.realm == nil,
                 let existingKeyword = realm.object(ofType: Keyword.self, forPrimaryKey: newKeyword.name) {


### PR DESCRIPTION
After examining the algorithm for creating the schedule groupings, I realized that we only need them sorted by time. The SessionInstance.standardSort is very complex and reaches across linking objects. As a result, large amounts of memory must be used as every object in the graph has to be materialized.

Before:

<img width="1167" alt="Screenshot 2023-06-08 at 3 34 37 PM" src="https://github.com/insidegui/WWDC/assets/8225090/832814a7-ffc4-4112-a5d1-4e467c003b8b">


After:
![Screenshot 2023-06-08 at 3 30 43 PM](https://github.com/insidegui/WWDC/assets/8225090/27cf229c-7f6e-4dd9-bde6-e00c3fa5b916)

