### PR TITLE
Fixed missing explicit self in iCloud code

### DIFF
--- a/Packages/ConfCore/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/Packages/ConfCore/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/WWDC/LiveObserver.swift
+++ b/WWDC/LiveObserver.swift
@@ -221,11 +221,13 @@ private final class CloudKitLiveObserver: Logging {
                                                    subscriptionID: specialLiveEventsSubscriptionID,
                                                    options: options)
 
-            database.save(subscription) { _, error in
+            database.save(subscription) { [weak self] _, error in
+                guard let self = self else { return }
+
                 if let error = error {
-                    log.error("Error creating subscriptions: \(String(describing: error), privacy: .public)")
+                    self.log.error("Error creating subscriptions: \(String(describing: error), privacy: .public)")
                 } else {
-                    log.info("Subscriptions created")
+                    self.log.info("Subscriptions created")
                 }
             }
         #endif


### PR DESCRIPTION
There were a couple of missing explicit `self` references after the change to `Logger` in iCloud-only code.

Not sure what `contents.xcworkspacedata` is about 🤔