### PR TITLE
Adopt Calendar write-only permission in macOS Sonoma

### DIFF
--- a/WWDC/Info.plist
+++ b/WWDC/Info.plist
@@ -74,6 +74,8 @@
 	</dict>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Calendar access allows you to add events directly from the app to help you plan your WWDC week.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>Add WWDC sessions and events to Calendar.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(COPYRIGHT)</string>
 	<key>NSMainStoryboardFile</key>


### PR DESCRIPTION
Since all we do is write to the calendar, we don't need full access.

There's a compile-time check so that the app keeps building just fine in Xcode 14. I wanted something like `#if __MAC_OS_X_VERSION_MAX_ALLOWED` in Swift, but apparently the only way to do a compile-time check for SDK is by using the `#compiler` directive. If you know of a better solution let me know.

![CleanShot 2023-06-10 at 10 30 09@2x](https://github.com/insidegui/WWDC/assets/67184/4b9b87df-6d9d-46b0-87e1-fba73d744901)
