### PR TITLE
Load git contributors only when about window is shown

### DIFF
--- a/WWDC/AppCoordinator.swift
+++ b/WWDC/AppCoordinator.swift
@@ -299,8 +299,6 @@ final class AppCoordinator: Logging {
     }()
 
     func startup() {
-        ContributorsFetcher.shared.load()
-
         windowController.contentViewController = tabController
         windowController.showWindow(self)
 
@@ -438,6 +436,8 @@ final class AppCoordinator: Logging {
         ContributorsFetcher.shared.infoTextChangedCallback = { [unowned self] newText in
             self.aboutWindowController.infoText = newText
         }
+
+        ContributorsFetcher.shared.load()
 
         return aboutWC
     }()


### PR DESCRIPTION
I noticed this getting called every time the app launched. I figure that's a bit aggressive and it seems like it was designed to be lazy in the first place?