### PR TITLE
Remove keypath filter on SessionViewModel

### DIFF
--- a/WWDC/SessionCellView.swift
+++ b/WWDC/SessionCellView.swift
@@ -49,6 +49,7 @@ final class SessionCellView: NSView {
 
         guard let viewModel = viewModel else { return }
 
+        titleLabel.stringValue = viewModel.title
         viewModel.rxTitle.replaceError(with: "").driveUI(\.stringValue, on: titleLabel).store(in: &cancellables)
         viewModel.rxSubtitle.replaceError(with: "").driveUI(\.stringValue, on: subtitleLabel).store(in: &cancellables)
         viewModel.rxContext.replaceError(with: "").driveUI(\.stringValue, on: contextLabel).store(in: &cancellables)

--- a/WWDC/SessionViewModel.swift
+++ b/WWDC/SessionViewModel.swift
@@ -27,7 +27,7 @@ final class SessionViewModel {
     let trackName: String
 
     lazy var rxSession: some Publisher<Session, Error> = {
-        return session.valuePublisher(keyPaths: ["title"])
+        return session.valuePublisher()
     }()
 
     lazy var rxTranscriptAnnotations: AnyPublisher<List<TranscriptAnnotation>, Error> = {
@@ -43,7 +43,7 @@ final class SessionViewModel {
     }()
 
     lazy var rxTrack: some Publisher<Track, Error> = {
-        return track.valuePublisher(keyPaths: ["name"])
+        return track.valuePublisher()
     }()
 
     lazy var rxTitle: some Publisher<String, Error> = {


### PR DESCRIPTION
• Use `.modified` for Realm automatic updates to reduce unnecessary change notifications
• Short circuit empty `objects` for `public func modify<T>(_ objects: [T]` because Realm was still creating a transaction due to the `try backgroundRealm.write`
• Remove the KeyPath filter on `rxSession`. I added it because I was testing impact on performance. I think there some value there but we'd need to supply all the KeyPaths that affect display, just removing it for now.