### PR TITLE
Consistent PiP / full screen state, improved full screen transition

### DIFF
--- a/PlayerUI/Controllers/PUIDetachedPlaybackStatusViewController.swift
+++ b/PlayerUI/Controllers/PUIDetachedPlaybackStatusViewController.swift
@@ -10,8 +10,8 @@ import Cocoa
 
 public typealias PUISnapshotClosure = (@escaping (CGImage?) -> Void) -> Void
 
-public struct DetachedPlaybackStatus {
-    var id: String
+public struct DetachedPlaybackStatus: Identifiable {
+    public internal(set) var id: String
     var icon: NSImage
     var title: String
     var subtitle: String
@@ -118,7 +118,7 @@ public final class PUIDetachedPlaybackStatusViewController: NSViewController {
         return l
     }()
 
-    public  override func loadView() {
+    public override func loadView() {
         view = NSView()
         view.wantsLayer = true
         

--- a/PlayerUI/Controllers/PUIDetachedPlaybackStatusViewController.swift
+++ b/PlayerUI/Controllers/PUIDetachedPlaybackStatusViewController.swift
@@ -118,17 +118,6 @@ public final class PUIDetachedPlaybackStatusViewController: NSViewController {
         return l
     }()
 
-    private lazy var blackoutLayer: CALayer = {
-        let l = CALayer()
-
-        l.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-        l.backgroundColor = NSColor.black.cgColor
-        l.opacity = 0
-        l.zPosition = 10
-
-        return l
-    }()
-
     public  override func loadView() {
         view = NSView()
         view.wantsLayer = true
@@ -147,9 +136,6 @@ public final class PUIDetachedPlaybackStatusViewController: NSViewController {
         view.addSubview(stackView)
         stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
-
-        blackoutLayer.frame = view.bounds
-        container.addSublayer(blackoutLayer)
 
         hide()
     }

--- a/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
+++ b/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
@@ -30,4 +30,7 @@ public protocol PUIPlayerViewAppearanceDelegate: AnyObject {
     func playerViewShouldShowFullScreenButton(_ playerView: PUIPlayerView) -> Bool
     func playerViewShouldShowBackAndForward30SecondsButtons(_ playerView: PUIPlayerView) -> Bool
 
+    func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView)
+    func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView)
+
 }

--- a/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
+++ b/PlayerUI/Protocols/PUIPlayerViewDelegates.swift
@@ -18,7 +18,14 @@ public protocol PUIPlayerViewDelegate: AnyObject {
 
 }
 
-public protocol PUIPlayerViewAppearanceDelegate: AnyObject {
+public protocol PUIPlayerViewDetachedStatusPresenter: AnyObject {
+
+    func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView)
+    func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView)
+
+}
+
+public protocol PUIPlayerViewAppearanceDelegate: AnyObject, PUIPlayerViewDetachedStatusPresenter {
 
     func playerViewShouldShowTimelineView(_ playerView: PUIPlayerView) -> Bool
     func playerViewShouldShowSubtitlesControl(_ playerView: PUIPlayerView) -> Bool
@@ -29,8 +36,5 @@ public protocol PUIPlayerViewAppearanceDelegate: AnyObject {
     func playerViewShouldShowTimestampLabels(_ playerView: PUIPlayerView) -> Bool
     func playerViewShouldShowFullScreenButton(_ playerView: PUIPlayerView) -> Bool
     func playerViewShouldShowBackAndForward30SecondsButtons(_ playerView: PUIPlayerView) -> Bool
-
-    func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView)
-    func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView)
 
 }

--- a/PlayerUI/Util/AVPlayer+Layout.swift
+++ b/PlayerUI/Util/AVPlayer+Layout.swift
@@ -1,20 +1,23 @@
 import Cocoa
 import AVFoundation
+import ConfUIFoundation
 
 @MainActor
 public extension AVPlayer {
-    func layoutRect(with bounds: CGRect) -> CGRect? {
-        guard let videoTrack = currentItem?.tracks.first(where: { $0.assetTrack?.mediaType == .video })?.assetTrack else { return nil }
+    static let fallbackNaturalSize = CGSize(width: 1920, height: 1080)
 
-        let videoRect = AVMakeRect(aspectRatio: videoTrack.naturalSize, insideRect: bounds)
+    func fittingRect(with bounds: CGRect) -> CGRect {
+        let videoSize = currentItem?.tracks.first(where: { $0.assetTrack?.mediaType == .video })?.assetTrack?.naturalSize ?? Self.fallbackNaturalSize
 
-        guard videoRect.width.isFinite, videoRect.height.isFinite else { return nil }
+        let fittingRect = AVMakeRect(aspectRatio: videoSize, insideRect: bounds)
 
-        return videoRect
+        UILog("📐 Video size: \(videoSize), fitting size: \(fittingRect.size)")
+
+        return fittingRect
     }
 
     func updateLayout(guide: NSLayoutGuide, container: NSView, constraints: inout [NSLayoutConstraint]) {
-        guard let videoRect = layoutRect(with: container.bounds) else { return }
+        let videoRect = fittingRect(with: container.bounds)
 
         if guide.owningView == nil {
             container.addLayoutGuide(guide)

--- a/PlayerUI/Util/AVPlayer+Layout.swift
+++ b/PlayerUI/Util/AVPlayer+Layout.swift
@@ -1,0 +1,34 @@
+import Cocoa
+import AVFoundation
+
+@MainActor
+public extension AVPlayer {
+    func layoutRect(with bounds: CGRect) -> CGRect? {
+        guard let videoTrack = currentItem?.tracks.first(where: { $0.assetTrack?.mediaType == .video })?.assetTrack else { return nil }
+
+        let videoRect = AVMakeRect(aspectRatio: videoTrack.naturalSize, insideRect: bounds)
+
+        guard videoRect.width.isFinite, videoRect.height.isFinite else { return nil }
+
+        return videoRect
+    }
+
+    func updateLayout(guide: NSLayoutGuide, container: NSView, constraints: inout [NSLayoutConstraint]) {
+        guard let videoRect = layoutRect(with: container.bounds) else { return }
+
+        if guide.owningView == nil {
+            container.addLayoutGuide(guide)
+        }
+
+        NSLayoutConstraint.deactivate(constraints)
+
+        constraints = [
+            guide.widthAnchor.constraint(equalToConstant: videoRect.width),
+            guide.heightAnchor.constraint(equalToConstant: videoRect.height),
+            guide.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            guide.centerXAnchor.constraint(equalTo: container.centerXAnchor)
+        ]
+
+        NSLayoutConstraint.activate(constraints)
+    }
+}

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -406,15 +406,16 @@ public final class PUIPlayerView: NSView {
 
     private lazy var videoLayoutGuideConstraints = [NSLayoutConstraint]()
 
-    private var currentBounds = CGRect.zero
+    private var currentBounds: CGRect?
 
     private func updateVideoLayoutGuide() {
         guard let player else { return }
 
         guard bounds != currentBounds else { return }
-        currentBounds = bounds
 
         player.updateLayout(guide: videoLayoutGuide, container: self, constraints: &videoLayoutGuideConstraints)
+
+        currentBounds = bounds
     }
 
     deinit {

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -409,25 +409,12 @@ public final class PUIPlayerView: NSView {
     private var currentBounds = CGRect.zero
 
     private func updateVideoLayoutGuide() {
-        guard let videoTrack = player?.currentItem?.tracks.first(where: { $0.assetTrack?.mediaType == .video })?.assetTrack else { return }
+        guard let player else { return }
 
         guard bounds != currentBounds else { return }
         currentBounds = bounds
 
-        let videoRect = AVMakeRect(aspectRatio: videoTrack.naturalSize, insideRect: bounds)
-
-        guard videoRect.width.isFinite, videoRect.height.isFinite else { return }
-
-        NSLayoutConstraint.deactivate(videoLayoutGuideConstraints)
-
-        videoLayoutGuideConstraints = [
-            videoLayoutGuide.widthAnchor.constraint(equalToConstant: videoRect.width),
-            videoLayoutGuide.heightAnchor.constraint(equalToConstant: videoRect.height),
-            videoLayoutGuide.centerYAnchor.constraint(equalTo: centerYAnchor),
-            videoLayoutGuide.centerXAnchor.constraint(equalTo: centerXAnchor)
-        ]
-
-        NSLayoutConstraint.activate(videoLayoutGuideConstraints)
+        player.updateLayout(guide: videoLayoutGuide, container: self, constraints: &videoLayoutGuideConstraints)
     }
 
     deinit {

--- a/PlayerUI/Views/PUIPlayerView.swift
+++ b/PlayerUI/Views/PUIPlayerView.swift
@@ -1567,6 +1567,7 @@ extension PUIPlayerView: AVPictureInPictureControllerDelegate {
     }
 
     public func pictureInPictureControllerDidStartPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+        fullScreenButton.isHidden = true
         pipButton.state = .on
 
         invalidateTouchBar()
@@ -1605,6 +1606,8 @@ extension PUIPlayerView: AVPictureInPictureControllerDelegate {
                 window.deminiaturize(nil)
             }
         }
+
+        fullScreenButton.isHidden = false
 
         completionHandler(true)
     }

--- a/PlayerUI/Views/PUIPlayerWindow.swift
+++ b/PlayerUI/Views/PUIPlayerWindow.swift
@@ -22,6 +22,9 @@ open class PUIPlayerWindow: NSWindow {
         super.init(contentRect: contentRect, styleMask: effectiveStyle, backing: bufferingType, defer: flag)
 
         applyCustomizations()
+
+        backgroundColor = .clear
+        isOpaque = false
     }
 
     open override func awakeFromNib() {
@@ -236,7 +239,7 @@ private class PUIPlayerWindowContentView: NSView {
     }
 
     fileprivate override func draw(_ dirtyRect: NSRect) {
-        NSColor.black.setFill()
+        NSColor.clear.setFill()
         dirtyRect.fill()
     }
 

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		F4FB06A12A21493B00799F84 /* PreviewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB06A02A21493B00799F84 /* PreviewSupport.swift */; };
 		F4FB06BF2A216C1F00799F84 /* RemoteGlyph.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB06BE2A216C1F00799F84 /* RemoteGlyph.swift */; };
 		F4FB06C12A2178C000799F84 /* WWDCWindowContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB06C02A2178C000799F84 /* WWDCWindowContentViewController.swift */; };
+		F4FE95AC2C08FD6E005E76EC /* AVPlayer+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FE95AB2C08FD6E005E76EC /* AVPlayer+Layout.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -471,6 +472,7 @@
 		F4FB06A02A21493B00799F84 /* PreviewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSupport.swift; sourceTree = "<group>"; };
 		F4FB06BE2A216C1F00799F84 /* RemoteGlyph.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteGlyph.swift; sourceTree = "<group>"; };
 		F4FB06C02A2178C000799F84 /* WWDCWindowContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WWDCWindowContentViewController.swift; sourceTree = "<group>"; };
+		F4FE95AB2C08FD6E005E76EC /* AVPlayer+Layout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayer+Layout.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1025,6 +1027,7 @@
 			isa = PBXGroup;
 			children = (
 				DDF721B91ECA12A40054C503 /* AVPlayer+Validation.swift */,
+				F4FE95AB2C08FD6E005E76EC /* AVPlayer+Layout.swift */,
 				4DBFA4D920E160CB00BDF34B /* AVAsset+AsyncHelpers.swift */,
 				DDF721BB1ECA12A40054C503 /* NSEvent+ForceTouch.swift */,
 				DDF721BC1ECA12A40054C503 /* NSWindow+Snapshot.swift */,
@@ -1545,6 +1548,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F4FE95AC2C08FD6E005E76EC /* AVPlayer+Layout.swift in Sources */,
 				DDF721D11ECA12A40054C503 /* PUITimelineAnnotation.swift in Sources */,
 				DDF721D51ECA12A40054C503 /* AVPlayer+Validation.swift in Sources */,
 				DDF721CA1ECA12A40054C503 /* Images.swift in Sources */,

--- a/WWDC/AppCoordinator+Shelf.swift
+++ b/WWDC/AppCoordinator+Shelf.swift
@@ -91,7 +91,7 @@ extension AppCoordinator: ShelfViewControllerDelegate {
             currentPlaybackViewModel = playbackViewModel
 
             if currentPlayerController == nil {
-                currentPlayerController = VideoPlayerViewController(player: playbackViewModel.player, session: viewModel)
+                currentPlayerController = VideoPlayerViewController(player: playbackViewModel.player, session: viewModel, shelf: shelfController)
                 currentPlayerController?.playerWillRestoreUserInterfaceForPictureInPictureStop = { [weak self] in
                     self?.returnToPlayingSessionContext()
                 }

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import Combine
 import CoreMedia
+import PlayerUI
 
 protocol ShelfViewControllerDelegate: AnyObject {
     func shelfViewControllerDidSelectPlay(_ controller: ShelfViewController)

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -185,7 +185,12 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
     func showDetachedStatus() {
         guard detachedStatusController.parent != nil else { return }
 
+        /// Ensures video layout guide gets updated for this new detachment.
+        view.needsLayout = true
+
         detachedStatusController.show()
+
+        shelfView.isHidden = true
     }
 
     /// Hides detached status view without resetting state.
@@ -193,6 +198,8 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
         guard detachedStatusController.parent != nil else { return }
 
         detachedStatusController.hide()
+
+        shelfView.isHidden = false
     }
 
     func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
@@ -206,7 +213,8 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
         installDetachedStatusControllerIfNeeded()
 
         detachedStatusController.status = status
-        detachedStatusController.show()
+        
+        showDetachedStatus()
     }
 
     func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -105,6 +105,16 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
     private func updateBindings() {
         cancellables = []
 
+        if detachedSessionID != nil {
+            UILog("📚 Selected session: \(viewModel?.sessionIdentifier ?? "<nil>"), detached session: \(detachedSessionID ?? "<nil>")")
+        }
+
+        if viewModel?.sessionIdentifier != detachedSessionID {
+            hideDetachedStatus()
+        } else if let detachedSessionID, viewModel?.sessionIdentifier == detachedSessionID {
+            showDetachedStatus()
+        }
+
         guard let viewModel = viewModel else {
             shelfView.image = nil
             return
@@ -167,11 +177,30 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
 
     // MARK: - Detached Playback Status
 
+    /// ID of the session being displayed by the shelf when the player was detached.
+    private var detachedSessionID: String?
     private weak var detachedPlayer: AVPlayer?
+
+    /// Shows detached status view without modifying state.
+    func showDetachedStatus() {
+        guard detachedStatusController.parent != nil else { return }
+
+        detachedStatusController.show()
+    }
+
+    /// Hides detached status view without resetting state.
+    func hideDetachedStatus() {
+        guard detachedStatusController.parent != nil else { return }
+
+        detachedStatusController.hide()
+    }
 
     func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
         guard let player = playerView.player else { return }
 
+        UILog("📚 Detaching with \(viewModel?.sessionIdentifier ?? "<nil>")")
+
+        self.detachedSessionID = viewModel?.sessionIdentifier
         self.detachedPlayer = player
 
         installDetachedStatusControllerIfNeeded()
@@ -181,10 +210,9 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
     }
 
     func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
-        guard detachedStatusController.parent != nil else { return }
+        hideDetachedStatus()
 
-        detachedStatusController.hide()
-
+        self.detachedSessionID = nil
         self.detachedPlayer = nil
     }
 

--- a/WWDC/ShelfViewController.swift
+++ b/WWDC/ShelfViewController.swift
@@ -186,12 +186,11 @@ final class ShelfViewController: NSViewController, PUIPlayerViewDetachedStatusPr
     func showDetachedStatus() {
         guard detachedStatusController.parent != nil else { return }
 
-        /// Ensures video layout guide gets updated for this new detachment.
-        view.needsLayout = true
-
         detachedStatusController.show()
 
         shelfView.isHidden = true
+
+        view.needsLayout = true
     }
 
     /// Hides detached status view without resetting state.

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -87,7 +87,6 @@ final class VideoPlayerViewController: NSViewController {
     override func loadView() {
         view = NSView(frame: NSRect.zero)
         view.wantsLayer = true
-        view.layer?.backgroundColor = NSColor.black.cgColor
 
         playerView.translatesAutoresizingMaskIntoConstraints = false
         playerView.frame = view.bounds

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -388,11 +388,11 @@ extension VideoPlayerViewController: PUIPlayerViewAppearanceDelegate {
     }
 
     func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
-        #warning("TODO: Implement")
+        shelf?.presentDetachedStatus(status, for: playerView)
     }
 
     func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
-        #warning("TODO: Implement")
+        shelf?.dismissDetachedStatus(status, for: playerView)
     }
 }
 

--- a/WWDC/VideoPlayerViewController.swift
+++ b/WWDC/VideoPlayerViewController.swift
@@ -51,9 +51,12 @@ final class VideoPlayerViewController: NSViewController {
     var playerWillRestoreUserInterfaceForPictureInPictureStop: (() -> Void)?
     var playerWillExitFullScreen: (() -> Void)?
 
-    init(player: AVPlayer, session: SessionViewModel) {
+    private weak var shelf: ShelfViewController?
+
+    init(player: AVPlayer, session: SessionViewModel, shelf: ShelfViewController) {
         sessionViewModel = session
         self.player = player
+        self.shelf = shelf
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -382,6 +385,14 @@ extension VideoPlayerViewController: PUIPlayerViewAppearanceDelegate {
 
     func playerViewShouldShowBackAndForward30SecondsButtons(_ playerView: PUIPlayerView) -> Bool {
         return Preferences.shared.skipBackAndForwardBy30Seconds
+    }
+
+    func presentDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
+        #warning("TODO: Implement")
+    }
+
+    func dismissDetachedStatus(_ status: DetachedPlaybackStatus, for playerView: PUIPlayerView) {
+        #warning("TODO: Implement")
     }
 }
 


### PR DESCRIPTION
Addresses this, originally reported by @allenhumphreys in #695:

> This isn't from your work, but I noticed full screen mode doesn't use the external player status which feels inconsistent. In full screen, you just see the video poster image. This is likely because the entire player view moves to the full screen window.