### PR TITLE
Event hero / live event improvements

### DIFF
--- a/Packages/ConfCore/ConfCore/AppleAPIClient.swift
+++ b/Packages/ConfCore/ConfCore/AppleAPIClient.swift
@@ -196,7 +196,7 @@ public final class AppleAPIClient: Logging, Signposting {
         }
 
         currentConfigRequest?.cancel()
-        currentConfigRequest = configResource.loadIfNeeded()
+        currentConfigRequest = configResource.load()
     }
 
 }


### PR DESCRIPTION
- Ensure `config.json` is fetched regardless of local cache state
- Delete existing event hero and write new one to storage within the same transaction
- Require live session `CKRecord` to have `overrideState=1` in order to override existing local sate fetched from the API