### PR TITLE
Use realm-swift with Realm.xcframework binaryTarget

### DIFF
--- a/Packages/ConfCore/Package.swift
+++ b/Packages/ConfCore/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
         .package(url: "https://github.com/bustoutsolutions/siesta", from: "1.5.2"),
-        .package(url: "https://github.com/realm/realm-swift", from: "10.0.0"),
+        .package(url: "https://github.com/insidegui/realm-swift.git", exact: "20.0.3"),
         .package(url: "https://github.com/insidegui/CloudKitCodable", branch: "spm"),
         .package(path: "../Transcripts")
 	],

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Please read the [contribution guidelines](CONTRIBUTING.md) before opening an iss
 A number of third-party libraries are used by the app:
 
 - [Realm](https://realm.io): data storage and caching
+    - **Note**: We have a [fork](https://github.com/insidegui/realm-swift) that swaps a `target` for a [`binaryTarget`](https://github.com/insidegui/realm-swift/pull/1). If this causes trouble in the future, consider switching back to the "normal" realm-swift. @SeeAlso: [PR 732](https://github.com/insidegui/WWDC/pull/732)
 - [Sparkle](https://sparkle-project.org/): automatic updates
 - [CloudKitCodable](https://github.com/insidegui/CloudKitCodable): sync support
 - [Siesta](http://bustoutsolutions.github.io/siesta/): networking

--- a/WWDC.xcodeproj/project.pbxproj
+++ b/WWDC.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		911C72C92A52169A00CB3757 /* CombineLatestMany.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911C72C82A52169A00CB3757 /* CombineLatestMany.swift */; };
 		914367202A4C6B0E004E4392 /* Sequence+GroupedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9143671F2A4C6B0E004E4392 /* Sequence+GroupedBy.swift */; };
 		914C83B42E1ECBFF001AEE5C /* SessionDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914C83B32E1ECBFF001AEE5C /* SessionDetailsView.swift */; };
+		9171CEFC2E5391CF0063BBA7 /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 91973A9B2E538BE200C4A644 /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		91973A9C2E538BE200C4A644 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 91973A9B2E538BE200C4A644 /* RealmSwift */; };
 		91C2A0BC2A4DE9B60049B6B7 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = 91C2A0BB2A4DE9B60049B6B7 /* OrderedCollections */; };
 		91DB93E82E1FF610002E8716 /* IsSelected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DB93E72E1FF60C002E8716 /* IsSelected.swift */; };
 		91DB9FD02E21777E002E8716 /* CursorShapeViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DB9FCF2E21777E002E8716 /* CursorShapeViewModifier.swift */; };
@@ -264,6 +266,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				9171CEFC2E5391CF0063BBA7 /* RealmSwift in Embed Frameworks */,
 				DD600AB82487F1730071B90E /* ConfUIFoundation.framework in Embed Frameworks */,
 				DDB1A2642577E67A00995FF1 /* ConfCore in Embed Frameworks */,
 				DDF7219E1ECA12780054C503 /* PlayerUI.framework in Embed Frameworks */,
@@ -528,6 +531,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91973A9C2E538BE200C4A644 /* RealmSwift in Frameworks */,
 				012BEFA41EE8658F007E72CA /* EventKit.framework in Frameworks */,
 				DDF7219D1ECA12780054C503 /* PlayerUI.framework in Frameworks */,
 				DDB1A2632577E67A00995FF1 /* ConfCore in Frameworks */,
@@ -1294,6 +1298,7 @@
 				DDB1A2622577E67A00995FF1 /* ConfCore */,
 				DDB1A2692577E7E900995FF1 /* Sparkle */,
 				91C2A0BB2A4DE9B60049B6B7 /* OrderedCollections */,
+				91973A9B2E538BE200C4A644 /* RealmSwift */,
 			);
 			productName = WWDC;
 			productReference = DD36A4AC1E478C6A00B2EA88 /* WWDC.app */;
@@ -1422,6 +1427,7 @@
 				DDB1A2682577E7E900995FF1 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				91C2A0BA2A4DE9B60049B6B7 /* XCRemoteSwiftPackageReference "swift-collections" */,
 				F4F189742C0773C9006EA9A2 /* XCRemoteSwiftPackageReference "MacPreviewUtils" */,
+				91973A9A2E538BE200C4A644 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = DD36A4AD1E478C6A00B2EA88 /* Products */;
 			projectDirPath = "";
@@ -2534,6 +2540,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		91973A9A2E538BE200C4A644 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/insidegui/realm-swift.git";
+			requirement = {
+				kind = exactVersion;
+				version = 20.0.3;
+			};
+		};
 		91C2A0BA2A4DE9B60049B6B7 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-collections.git";
@@ -2561,6 +2575,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		91973A9B2E538BE200C4A644 /* RealmSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 91973A9A2E538BE200C4A644 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			productName = RealmSwift;
+		};
 		91C2A0BB2A4DE9B60049B6B7 /* OrderedCollections */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 91C2A0BA2A4DE9B60049B6B7 /* XCRemoteSwiftPackageReference "swift-collections" */;

--- a/WWDC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WWDC.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,21 +28,12 @@
       }
     },
     {
-      "identity" : "realm-core",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/realm-core.git",
-      "state" : {
-        "revision" : "f1434caadda443b4ed2261b91ea4f43ab1ee2aa5",
-        "version" : "13.15.1"
-      }
-    },
-    {
       "identity" : "realm-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/realm-swift",
+      "location" : "https://github.com/insidegui/realm-swift.git",
       "state" : {
-        "revision" : "b287dc102036ff425bd8a88483f0a5596871f05e",
-        "version" : "10.41.0"
+        "revision" : "f7e11c65f7213014e3c17f040da3d1c51d95dee7",
+        "version" : "20.0.3"
       }
     },
     {


### PR DESCRIPTION
# Motivation

1. realm-core takes a long time to build
2. SPM doesn't let us specify that for a particular dependency we do NOT want a debug build
3. Realm is VERY VERY slow when built for debug, which is fine for them, but when developing the app, it leads to ambiguity as to whether our implementation of realm is slow, or if it's just the realm debug build.

# Solution

Use Realm & realm-core binary dependencies!

## Explanation

realm-swift has 2 products:
1. Realm (realm-core is statically linked)
4. RealmSwift

Realm depends on realm-core and is written in Objective-C++. 

RealmSwift depends on Realm.

After the versions are released, Realm is available as a binary on the realm-swift release. Swapping in that binary means we will get release build of Realm and realm-core. RealmSwift will still be built from source because they're not using library evolution or whatever which means you need a specific swift compiler binary output to match to your Xcode version. RealmSwift is actually a relatively thin wrapper around the other 2 libraries and doesn't contribute a lot to the performance ambiguity.

Other approach explored in #730 