### PR TITLE
Get IDEProvisioningTeamByIdentifier first when scanning existing teams

### DIFF
--- a/teamid.sh
+++ b/teamid.sh
@@ -8,6 +8,22 @@ function print_team_ids() {
   echo ""
   
   XCODEPREFS="$HOME/Library/Preferences/com.apple.dt.Xcode.plist"
+
+  # Get all team infos and format as key-value pairs
+  local all_keys=($(/usr/libexec/PlistBuddy -c "Print :IDEProvisioningTeamByIdentifier" "$XCODEPREFS" | grep ' = Array' | awk '{print $1}'))
+  local result=""
+  for key in "${all_keys[@]}"; do
+      local teamID=$(/usr/libexec/PlistBuddy -c "Print :IDEProvisioningTeamByIdentifier:$key:0:teamID" "$XCODEPREFS" 2>/dev/null)
+      local teamName=$(/usr/libexec/PlistBuddy -c "Print :IDEProvisioningTeamByIdentifier:$key:0:teamName" "$XCODEPREFS" 2>/dev/null)
+      if [ -n "$teamID" ]; then
+          result+="$teamID - $teamName\n"
+      fi
+  done
+  if [ -n "$result" ]; then
+      printf "%b" "$result"
+      return 0
+  fi
+  
   TEAM_KEYS=(`/usr/libexec/PlistBuddy -c "Print :IDEProvisioningTeams" "$XCODEPREFS" | perl -lne 'print $1 if /^    (\S*) =/'`)
   
   for KEY in $TEAM_KEYS 

--- a/teamid.sh
+++ b/teamid.sh
@@ -9,7 +9,7 @@ function print_team_ids() {
   
   XCODEPREFS="$HOME/Library/Preferences/com.apple.dt.Xcode.plist"
 
-  # Get all team infos and format as key-value pairs
+  # Get all team infos from IDEProvisioningTeamByIdentifier, for Xcode versions after 16.0
   local all_keys=($(/usr/libexec/PlistBuddy -c "Print :IDEProvisioningTeamByIdentifier" "$XCODEPREFS" | grep ' = Array' | awk '{print $1}'))
   local result=""
   for key in "${all_keys[@]}"; do
@@ -24,6 +24,8 @@ function print_team_ids() {
       return 0
   fi
   
+  # Get all team infos from IDEProvisioningTeams, for Xcode versions prior to 16.0
+  # More info: https://support.apple.com/en-us/121239#:~:text=CVE%2D2024%2D40862:%20Guilherme%20Rambo%20of%20Best%20Buddy%20Apps%20(rambo.codes)
   TEAM_KEYS=(`/usr/libexec/PlistBuddy -c "Print :IDEProvisioningTeams" "$XCODEPREFS" | perl -lne 'print $1 if /^    (\S*) =/'`)
   
   for KEY in $TEAM_KEYS 


### PR DESCRIPTION
IDEProvisioningTeams appears to be deprecated for a clean install of Xcode 26.