### PR TITLE
chore: disable redundant optional init lint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ disabled_rules:
   - for_where
   - opening_brace
   - vertical_parameter_alignment
+  - redundant_optional_initialization
 
 opt_in_rules:
   - redundant_nil_coalescing


### PR DESCRIPTION
## Summary
- disable SwiftLint's redundant_optional_initialization rule globally
- avoids per-property suppression comments for property wrappers that require explicit nil initialization

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".swiftlint.yml"); puts "ok .swiftlint.yml"'
- git diff --check

I could not run SwiftLint locally because the swiftlint executable is not installed in this environment.

AI disclosure: This contribution was prepared with assistance from OpenAI Codex under human review.

Closes #743