### PR TITLE
Add UIDesignRequiresCompatibility to Info.plist

### DIFF
--- a/WWDC/Resources/Info.plist
+++ b/WWDC/Resources/Info.plist
@@ -88,5 +88,7 @@
 	<string>https://github.com/insidegui/WWDC/raw/master/Releases/appcast_v5.xml</string>
 	<key>SUScheduledCheckInterval</key>
 	<integer>86400</integer>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
So we can build the app in Xcode 26 without having to support Liquid Glass (for now).

P.S.: it will be very funny when macOS 27 beta comes out in a few weeks and it completely ignores that flag 🙈