### PR TITLE
Add collapsible session list sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Pods/
 Carthage
 Provisioning
 TeamID.xcconfig
+CLAUDE.md

--- a/WWDC/Bootstrap/AppCoordinator.swift
+++ b/WWDC/Bootstrap/AppCoordinator.swift
@@ -248,6 +248,15 @@ final class AppCoordinator: Logging, Signposting {
         videosController.listViewController.$selectedSession.assign(to: &self.$videosSelectedSessionViewModel)
         scheduleController.splitViewController.listViewController.$selectedSession.assign(to: &self.$scheduleSelectedSessionViewModel)
 
+        // Enable the sidebar toggle only on tabs that have a session-list sidebar.
+        tabController.$activeTabVar
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] activeTab in
+                guard let self else { return }
+                self.windowController.titleBarViewController.sidebarToggleButton.isEnabled = activeTab.hasSidebar
+            }
+            .store(in: &cancellables)
+
         Publishers.CombineLatest3(
             tabController.$activeTabVar,
             $videosSelectedSessionViewModel,
@@ -256,10 +265,6 @@ final class AppCoordinator: Logging, Signposting {
             .sink { [weak self] (activeTab, _, _) in
                 guard let self else { return }
                 self.activeTab = activeTab
-
-                // The sidebar toggle only applies to tabs that have a session-list sidebar.
-                let hasSidebar = (activeTab == .schedule || activeTab == .videos)
-                self.windowController.titleBarViewController.sidebarToggleButton.isEnabled = hasSidebar
 
                 switch activeTab {
                 case .schedule:

--- a/WWDC/Bootstrap/AppCoordinator.swift
+++ b/WWDC/Bootstrap/AppCoordinator.swift
@@ -257,6 +257,10 @@ final class AppCoordinator: Logging, Signposting {
                 guard let self else { return }
                 self.activeTab = activeTab
 
+                // The sidebar toggle only applies to tabs that have a session-list sidebar.
+                let hasSidebar = (activeTab == .schedule || activeTab == .videos)
+                self.windowController.titleBarViewController.sidebarToggleButton.isEnabled = hasSidebar
+
                 switch activeTab {
                 case .schedule:
                     activeTabSelectedSessionViewModel = scheduleSelectedSessionViewModel

--- a/WWDC/Controllers/Base/MainWindowController.swift
+++ b/WWDC/Controllers/Base/MainWindowController.swift
@@ -23,6 +23,9 @@ enum MainWindowTab: Int, WWDCTab {
     }
 
     var hidesWindowTitleBar: Bool { self == .explore }
+
+    /// Whether this tab shows the collapsible session-list sidebar.
+    var hasSidebar: Bool { self == .schedule || self == .videos }
 }
 
 extension Notification.Name {

--- a/WWDC/Controllers/Base/MainWindowController.swift
+++ b/WWDC/Controllers/Base/MainWindowController.swift
@@ -41,11 +41,14 @@ final class MainWindowController: WWDCWindowController {
         return NSScreen.main?.visibleFrame.insetBy(dx: 50, dy: 120) ??
                NSRect(x: 0, y: 0, width: 1200, height: 600)
     }
-    public var sidebarInitWidth: CGFloat?
 
-    /// Shared, session-only collapsed state for the session-list sidebar, so both
-    /// tabs agree and a lazily-loaded tab adopts the current state. Not persisted.
-    public var sidebarCollapsed = false
+    /// Shared, session-only sidebar layout state so both tabs agree and a
+    /// lazily-loaded tab adopts the current state. Not persisted across launches.
+    struct SidebarState {
+        var initialWidth: CGFloat?
+        var collapsed = false
+    }
+    var sidebarState = SidebarState()
 
     override func loadWindow() {
         let mask: NSWindow.StyleMask = [.titled, .resizable, .miniaturizable, .closable, .fullSizeContentView]

--- a/WWDC/Controllers/Base/MainWindowController.swift
+++ b/WWDC/Controllers/Base/MainWindowController.swift
@@ -43,6 +43,10 @@ final class MainWindowController: WWDCWindowController {
     }
     public var sidebarInitWidth: CGFloat?
 
+    /// Shared, session-only collapsed state for the session-list sidebar, so both
+    /// tabs agree and a lazily-loaded tab adopts the current state. Not persisted.
+    public var sidebarCollapsed = false
+
     override func loadWindow() {
         let mask: NSWindow.StyleMask = [.titled, .resizable, .miniaturizable, .closable, .fullSizeContentView]
         let window = WWDCWindow(contentRect: MainWindowController.defaultRect, styleMask: mask, backing: .buffered, defer: false)

--- a/WWDC/Controllers/Base/TitleBarViewController.swift
+++ b/WWDC/Controllers/Base/TitleBarViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import OSLog
 
 final class TitleBarViewController: NSTitlebarAccessoryViewController {
 
@@ -48,14 +49,34 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
         return v
     }()
 
+    private static let log = Logger(subsystem: Bundle.main.bundleIdentifier ?? "io.wwdc.app", category: "TitleBarViewController")
+
     private static func makeToggleSymbol() -> NSImage {
         guard let image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: "Toggle Sidebar") else {
             assertionFailure("Missing system symbol: sidebar.left")
-            return NSImage()
+            log.error("Missing system symbol sidebar.left; falling back to a text glyph for the sidebar toggle")
+            return fallbackToggleSymbol()
         }
         // withSymbolConfiguration returns nil if the configuration can't be applied;
         // fall back to the unconfigured symbol rather than a blank image.
         return image.withSymbolConfiguration(.init(pointSize: 15, weight: .regular)) ?? image
+    }
+
+    /// Visible last-resort glyph so the toggle button never renders blank if the
+    /// system symbol is unavailable.
+    private static func fallbackToggleSymbol() -> NSImage {
+        let glyph = "◧" as NSString
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 15, weight: .regular),
+            .foregroundColor: NSColor.labelColor
+        ]
+        let glyphSize = glyph.size(withAttributes: attributes)
+        let image = NSImage(size: NSSize(width: ceil(glyphSize.width), height: ceil(glyphSize.height)))
+        image.lockFocus()
+        glyph.draw(at: .zero, withAttributes: attributes)
+        image.unlockFocus()
+        image.isTemplate = true
+        return image
     }
 
     /// Sidebar collapse/expand toggle. Fires `toggleSidebar:` up the responder chain

--- a/WWDC/Controllers/Base/TitleBarViewController.swift
+++ b/WWDC/Controllers/Base/TitleBarViewController.swift
@@ -48,14 +48,21 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
         return v
     }()
 
+    private static func makeToggleSymbol() -> NSImage {
+        guard let image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: "Toggle Sidebar") else {
+            assertionFailure("Missing system symbol: sidebar.left")
+            return NSImage()
+        }
+        // withSymbolConfiguration returns nil if the configuration can't be applied;
+        // fall back to the unconfigured symbol rather than a blank image.
+        return image.withSymbolConfiguration(.init(pointSize: 15, weight: .regular)) ?? image
+    }
+
     /// Sidebar collapse/expand toggle. Fires `toggleSidebar:` up the responder chain
     /// so it reaches the active tab's split view controller. Exposed so the coordinator
     /// can disable it on tabs that have no sidebar (Explore).
     lazy var sidebarToggleButton: NSButton = {
-        let symbol = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: "Toggle Sidebar")
-        let configured = symbol?.withSymbolConfiguration(.init(pointSize: 15, weight: .regular))
-
-        let b = NSButton(image: configured ?? NSImage(), target: nil, action: #selector(NSSplitViewController.toggleSidebar(_:)))
+        let b = NSButton(image: Self.makeToggleSymbol(), target: nil, action: #selector(NSSplitViewController.toggleSidebar(_:)))
         b.translatesAutoresizingMaskIntoConstraints = false
         b.isBordered = false
         b.imagePosition = .imageOnly
@@ -134,10 +141,14 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
         centerOffset = localWindowBounds.midX - view.bounds.midX
 
         // Tuck the sidebar toggle right up against the rightmost traffic-light (zoom) button.
-        if let zoomButton = window.standardWindowButton(.zoomButton), let buttonSuperview = zoomButton.superview {
+        if let constraint = leadingButtonConstraint,
+           let zoomButton = window.standardWindowButton(.zoomButton),
+           let buttonSuperview = zoomButton.superview {
             let frameInWindow = buttonSuperview.convert(zoomButton.frame, to: nil)
-            let maxXInView = view.convert(frameInWindow, from: nil).maxX
-            leadingButtonConstraint?.constant = maxXInView + Self.trafficLightGap
+            let newConstant = view.convert(frameInWindow, from: nil).maxX + Self.trafficLightGap
+            if abs(constraint.constant - newConstant) > 0.5 {
+                constraint.constant = newConstant
+            }
         }
     }
 

--- a/WWDC/Controllers/Base/TitleBarViewController.swift
+++ b/WWDC/Controllers/Base/TitleBarViewController.swift
@@ -12,8 +12,14 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
 
     private var horizontalPositioningConstraints = [NSLayoutConstraint]()
 
-    /// Approximate inset that clears the window's traffic-light controls.
+    /// Fallback leading inset used until the traffic-light buttons can be measured.
     private static let trafficLightInset: CGFloat = 76
+
+    /// Gap between the rightmost traffic-light (zoom) button and the sidebar toggle.
+    private static let trafficLightGap: CGFloat = 8
+
+    /// Leading constraint for the toggle button; its constant tracks the traffic lights.
+    private var leadingButtonConstraint: NSLayoutConstraint?
 
     private var centerOffset: CGFloat = 0 {
         didSet {
@@ -91,7 +97,9 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
 
         leadingContainer.addSubview(sidebarToggleButton)
 
-        leadingContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Self.trafficLightInset).isActive = true
+        let leadingConstraint = leadingContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Self.trafficLightInset)
+        leadingConstraint.isActive = true
+        leadingButtonConstraint = leadingConstraint
         leadingContainer.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         leadingContainer.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
 
@@ -124,6 +132,13 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
         let windowBounds = window.convertFromScreen(window.frame)
         let localWindowBounds = view.convert(windowBounds, from: nil)
         centerOffset = localWindowBounds.midX - view.bounds.midX
+
+        // Tuck the sidebar toggle right up against the rightmost traffic-light (zoom) button.
+        if let zoomButton = window.standardWindowButton(.zoomButton), let buttonSuperview = zoomButton.superview {
+            let frameInWindow = buttonSuperview.convert(zoomButton.frame, to: nil)
+            let maxXInView = view.convert(frameInWindow, from: nil).maxX
+            leadingButtonConstraint?.constant = maxXInView + Self.trafficLightGap
+        }
     }
 
     func replace(child: NSViewController?, with newChild: NSViewController?, inContainer container: NSView) {

--- a/WWDC/Controllers/Base/TitleBarViewController.swift
+++ b/WWDC/Controllers/Base/TitleBarViewController.swift
@@ -6,11 +6,14 @@
 //  Copyright © 2018 Guilherme Rambo. All rights reserved.
 //
 
-import Foundation
+import Cocoa
 
 final class TitleBarViewController: NSTitlebarAccessoryViewController {
 
     private var horizontalPositioningConstraints = [NSLayoutConstraint]()
+
+    /// Approximate inset that clears the window's traffic-light controls.
+    private static let trafficLightInset: CGFloat = 76
 
     private var centerOffset: CGFloat = 0 {
         didSet {
@@ -30,6 +33,31 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
         v.translatesAutoresizingMaskIntoConstraints = false
 
         return v
+    }()
+
+    private lazy var leadingContainer: NSView = {
+        let v = NSView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+
+        return v
+    }()
+
+    /// Sidebar collapse/expand toggle. Fires `toggleSidebar:` up the responder chain
+    /// so it reaches the active tab's split view controller. Exposed so the coordinator
+    /// can disable it on tabs that have no sidebar (Explore).
+    lazy var sidebarToggleButton: NSButton = {
+        let symbol = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: "Toggle Sidebar")
+        let configured = symbol?.withSymbolConfiguration(.init(pointSize: 15, weight: .regular))
+
+        let b = NSButton(image: configured ?? NSImage(), target: nil, action: #selector(NSSplitViewController.toggleSidebar(_:)))
+        b.translatesAutoresizingMaskIntoConstraints = false
+        b.isBordered = false
+        b.imagePosition = .imageOnly
+        b.setButtonType(.momentaryChange)
+        b.imageScaling = .scaleProportionallyDown
+        b.toolTip = "Toggle Sidebar"
+
+        return b
     }()
 
     var statusViewController: NSViewController? {
@@ -57,14 +85,25 @@ final class TitleBarViewController: NSTitlebarAccessoryViewController {
     override func loadView() {
         let view = NSView()
 
+        view.addSubview(leadingContainer)
         view.addSubview(tabBarContainer)
         view.addSubview(statusContainer)
+
+        leadingContainer.addSubview(sidebarToggleButton)
+
+        leadingContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Self.trafficLightInset).isActive = true
+        leadingContainer.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        leadingContainer.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
+
+        sidebarToggleButton.leadingAnchor.constraint(equalTo: leadingContainer.leadingAnchor).isActive = true
+        sidebarToggleButton.trailingAnchor.constraint(equalTo: leadingContainer.trailingAnchor).isActive = true
+        sidebarToggleButton.centerYAnchor.constraint(equalTo: leadingContainer.centerYAnchor).isActive = true
 
         let centerXConstraint = tabBarContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         centerXConstraint.isActive = true
         horizontalPositioningConstraints.append(centerXConstraint)
         tabBarContainer.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
-        tabBarContainer.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor).isActive = true
+        tabBarContainer.leadingAnchor.constraint(greaterThanOrEqualTo: leadingContainer.trailingAnchor, constant: 8).isActive = true
         tabBarContainer.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor).isActive = true
 
         statusContainer.leadingAnchor.constraint(equalTo: tabBarContainer.trailingAnchor).isActive = true

--- a/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
+++ b/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
@@ -130,7 +130,7 @@ final class SessionsSplitViewController: NSSplitViewController {
         guard notificationSourceSplitView !== splitView else {
             // If own split view is altered, change split view initialisation width for other tabs.
             // Skip while collapsed so the ~0pt collapsed width is never persisted as the sidebar width.
-            if !sidebarItem.isCollapsed {
+            if !sidebarItem.isCollapsed, notificationSourceSplitView.subviews.indices.contains(targetSubviewIndex) {
                 windowController.sidebarState.initialWidth = notificationSourceSplitView.subviews[targetSubviewIndex].bounds.width
             }
             return
@@ -139,7 +139,8 @@ final class SessionsSplitViewController: NSSplitViewController {
         // Width-sync is throttled 250 ms so a trailing notification can arrive after
         // the collapse-sync; calling setPosition here would re-expand the sidebar.
         guard !sidebarItem.isCollapsed else { return }
-        guard splitView.subviews.count > 0, notificationSourceSplitView.subviews.count > 0 else {
+        guard splitView.subviews.indices.contains(targetSubviewIndex),
+              notificationSourceSplitView.subviews.indices.contains(targetSubviewIndex) else {
             return
         }
         guard splitView.subviews[targetSubviewIndex].bounds.width != notificationSourceSplitView.subviews[targetSubviewIndex].bounds.width else {

--- a/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
+++ b/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
@@ -23,6 +23,13 @@ final class SessionsSplitViewController: NSSplitViewController {
     var setupDone = false
     private var cancellables: Set<AnyCancellable> = []
 
+    /// The split view item hosting the session list sidebar. Retained so its
+    /// collapsed state can be toggled, observed and synced across tabs.
+    private var sidebarItem: NSSplitViewItem!
+
+    /// Guards against feedback loops while mirroring collapse state from another tab.
+    private var isSyncingCollapse = false
+
     init(windowController: MainWindowController, listViewController: SessionsTableViewController) {
         self.windowController = windowController
         self.listViewController = listViewController
@@ -39,6 +46,14 @@ final class SessionsSplitViewController: NSSplitViewController {
                 self?.syncSplitView(notification: notification)
             }
             .store(in: &cancellables)
+
+        NotificationCenter
+            .default
+            .publisher(for: .sidebarCollapseSyncNotification)
+            .sink { [weak self] notification in
+                self?.applyCollapseSync(notification: notification)
+            }
+            .store(in: &cancellables)
     }
 
     required init?(coder: NSCoder) {
@@ -51,7 +66,8 @@ final class SessionsSplitViewController: NSSplitViewController {
         view.wantsLayer = true
 
         let listItem = NSSplitViewItem(sidebarWithViewController: listViewController)
-        listItem.canCollapse = false
+        listItem.canCollapse = true
+        sidebarItem = listItem
         let detailItem = NSSplitViewItem(viewController: detailViewController)
 
         addSplitViewItem(listItem)
@@ -59,6 +75,24 @@ final class SessionsSplitViewController: NSSplitViewController {
 
         listViewController.view.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         detailViewController.view.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        // Mirror collapse state to the other tab's split view so both stay consistent
+        // during a session. Catches both the toggleSidebar: action and drag-to-collapse.
+        listItem
+            .publisher(for: \.isCollapsed)
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] collapsed in
+                guard let self, !self.isSyncingCollapse else { return }
+                // Record the shared session state so the other (possibly not-yet-loaded) tab adopts it.
+                self.windowController.sidebarCollapsed = collapsed
+                NotificationCenter.default.post(
+                    name: .sidebarCollapseSyncNotification,
+                    object: self.splitView,
+                    userInfo: ["collapsed": collapsed]
+                )
+            }
+            .store(in: &cancellables)
     }
 
     override func viewWillAppear() {
@@ -67,6 +101,13 @@ final class SessionsSplitViewController: NSSplitViewController {
         if !setupDone {
             if let sidebarInitWidth = windowController.sidebarInitWidth {
                 splitView.setPosition(sidebarInitWidth, ofDividerAt: 0)
+            }
+            // Adopt the shared collapsed state in case it changed in another tab before
+            // this one was lazily loaded.
+            if sidebarItem.isCollapsed != windowController.sidebarCollapsed {
+                isSyncingCollapse = true
+                sidebarItem.isCollapsed = windowController.sidebarCollapsed
+                isSyncingCollapse = false
             }
             setupDone = true
         }
@@ -87,8 +128,11 @@ final class SessionsSplitViewController: NSSplitViewController {
 #endif
 
         guard notificationSourceSplitView !== splitView else {
-            // If own split view is altered, change split view initialisation width for other tabs
-            windowController.sidebarInitWidth = notificationSourceSplitView.subviews[targetSubviewIndex].bounds.width
+            // If own split view is altered, change split view initialisation width for other tabs.
+            // Skip while collapsed so the ~0pt collapsed width is never persisted as the sidebar width.
+            if !sidebarItem.isCollapsed {
+                windowController.sidebarInitWidth = notificationSourceSplitView.subviews[targetSubviewIndex].bounds.width
+            }
             return
         }
         guard splitView.subviews.count > 0, notificationSourceSplitView.subviews.count > 0 else {
@@ -108,12 +152,30 @@ final class SessionsSplitViewController: NSSplitViewController {
     override func splitViewDidResizeSubviews(_ notification: Notification) {
         guard isResizingSplitView == false else { return }
         guard setupDone else { return }
+        // Don't broadcast a width sync for a collapse/expand; collapse state has its own sync.
+        guard !sidebarItem.isCollapsed else { return }
 
         // This notification should only be posted in response to user input
         NotificationCenter.default.post(name: .sideBarSizeSyncNotification, object: splitView, userInfo: nil)
+    }
+
+    /// Mirrors a collapse/expand performed in another tab's split view onto this one.
+    private func applyCollapseSync(notification: Notification) {
+        // The split view item only exists once this tab's view has loaded. A not-yet-loaded
+        // tab will adopt the shared state via windowController.sidebarCollapsed in viewWillAppear.
+        guard let sidebarItem else { return }
+        guard let sourceSplitView = notification.object as? NSSplitView, sourceSplitView !== splitView else { return }
+        guard let collapsed = notification.userInfo?["collapsed"] as? Bool else { return }
+        guard sidebarItem.isCollapsed != collapsed else { return }
+
+        // The inactive tab isn't visible, so apply directly without animation.
+        isSyncingCollapse = true
+        sidebarItem.isCollapsed = collapsed
+        isSyncingCollapse = false
     }
 }
 
 extension Notification.Name {
     public static let sideBarSizeSyncNotification = NSNotification.Name("WWDCSplitViewSizeSyncNotification")
+    public static let sidebarCollapseSyncNotification = NSNotification.Name("WWDCSidebarCollapseSyncNotification")
 }

--- a/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
+++ b/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
@@ -49,7 +49,7 @@ final class SessionsSplitViewController: NSSplitViewController {
 
         NotificationCenter
             .default
-            .publisher(for: .sidebarCollapseSyncNotification)
+            .publisher(for: .sideBarCollapseSyncNotification)
             .sink { [weak self] notification in
                 self?.applyCollapseSync(notification: notification)
             }
@@ -87,7 +87,7 @@ final class SessionsSplitViewController: NSSplitViewController {
                 // Record the shared session state so the other (possibly not-yet-loaded) tab adopts it.
                 self.windowController.sidebarState.collapsed = collapsed
                 NotificationCenter.default.post(
-                    name: .sidebarCollapseSyncNotification,
+                    name: .sideBarCollapseSyncNotification,
                     object: self.splitView,
                     userInfo: ["collapsed": collapsed]
                 )
@@ -181,5 +181,5 @@ final class SessionsSplitViewController: NSSplitViewController {
 
 extension Notification.Name {
     public static let sideBarSizeSyncNotification = NSNotification.Name("WWDCSplitViewSizeSyncNotification")
-    public static let sidebarCollapseSyncNotification = NSNotification.Name("WWDCSidebarCollapseSyncNotification")
+    public static let sideBarCollapseSyncNotification = NSNotification.Name("WWDCSidebarCollapseSyncNotification")
 }

--- a/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
+++ b/WWDC/Controllers/Sessions/SessionsSplitViewController.swift
@@ -85,7 +85,7 @@ final class SessionsSplitViewController: NSSplitViewController {
             .sink { [weak self] collapsed in
                 guard let self, !self.isSyncingCollapse else { return }
                 // Record the shared session state so the other (possibly not-yet-loaded) tab adopts it.
-                self.windowController.sidebarCollapsed = collapsed
+                self.windowController.sidebarState.collapsed = collapsed
                 NotificationCenter.default.post(
                     name: .sidebarCollapseSyncNotification,
                     object: self.splitView,
@@ -99,14 +99,14 @@ final class SessionsSplitViewController: NSSplitViewController {
         super.viewWillAppear()
 
         if !setupDone {
-            if let sidebarInitWidth = windowController.sidebarInitWidth {
-                splitView.setPosition(sidebarInitWidth, ofDividerAt: 0)
+            if let initWidth = windowController.sidebarState.initialWidth {
+                splitView.setPosition(initWidth, ofDividerAt: 0)
             }
             // Adopt the shared collapsed state in case it changed in another tab before
             // this one was lazily loaded.
-            if sidebarItem.isCollapsed != windowController.sidebarCollapsed {
+            if sidebarItem.isCollapsed != windowController.sidebarState.collapsed {
                 isSyncingCollapse = true
-                sidebarItem.isCollapsed = windowController.sidebarCollapsed
+                sidebarItem.isCollapsed = windowController.sidebarState.collapsed
                 isSyncingCollapse = false
             }
             setupDone = true
@@ -131,10 +131,14 @@ final class SessionsSplitViewController: NSSplitViewController {
             // If own split view is altered, change split view initialisation width for other tabs.
             // Skip while collapsed so the ~0pt collapsed width is never persisted as the sidebar width.
             if !sidebarItem.isCollapsed {
-                windowController.sidebarInitWidth = notificationSourceSplitView.subviews[targetSubviewIndex].bounds.width
+                windowController.sidebarState.initialWidth = notificationSourceSplitView.subviews[targetSubviewIndex].bounds.width
             }
             return
         }
+        // If THIS tab's sidebar is already collapsed, skip applying the incoming width.
+        // Width-sync is throttled 250 ms so a trailing notification can arrive after
+        // the collapse-sync; calling setPosition here would re-expand the sidebar.
+        guard !sidebarItem.isCollapsed else { return }
         guard splitView.subviews.count > 0, notificationSourceSplitView.subviews.count > 0 else {
             return
         }
@@ -162,7 +166,7 @@ final class SessionsSplitViewController: NSSplitViewController {
     /// Mirrors a collapse/expand performed in another tab's split view onto this one.
     private func applyCollapseSync(notification: Notification) {
         // The split view item only exists once this tab's view has loaded. A not-yet-loaded
-        // tab will adopt the shared state via windowController.sidebarCollapsed in viewWillAppear.
+        // tab will adopt the shared state via windowController.sidebarState.collapsed in viewWillAppear.
         guard let sidebarItem else { return }
         guard let sourceSplitView = notification.object as? NSSplitView, sourceSplitView !== splitView else { return }
         guard let collapsed = notification.userInfo?["collapsed"] as? Bool else { return }

--- a/WWDC/Resources/Base.lproj/Main.storyboard
+++ b/WWDC/Resources/Base.lproj/Main.storyboard
@@ -557,6 +557,13 @@
                                                 <action selector="viewVideos:" target="Ady-hI-5gd" id="xWC-aO-kEM"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="wwd-c0-sb0"/>
+                                        <menuItem title="Hide Sidebar" keyEquivalent="s" id="wwd-c0-sb1">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="wwd-c0-sb2"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="eT5-6l-QRY"/>
                                         <menuItem title="Reload" keyEquivalent="r" id="VAB-X3-ZCo">
                                             <connections>


### PR DESCRIPTION
## Summary

Makes the session list sidebar collapsible in the Videos and Schedule tabs.
Previously the list was always visible, which in windowed mode kept the
video player narrower than the window allowed. You can now hide the list to
give the video the full width of the window, and show it again when you need
to pick another session.

The sidebar can be toggled three ways, all routed through AppKit's standard
toggleSidebar action: a button at the leading edge of the title bar, a Hide
Sidebar item in the View menu, and the Control-Command-S shortcut. The
collapsed state stays consistent between the Videos and Schedule tabs during
a session and is not persisted, so the app always starts with the sidebar
visible. Dragging the divider past its minimum width also collapses it.

Closes #763.

## Testing

Built with the WWDC scheme. Verified toggling from the title bar button, the
View menu, and the keyboard shortcut on both the Videos and Schedule tabs,
drag to collapse, cross tab consistency, the button disabling on the Explore
tab which has no sidebar, and the sidebar reopening expanded after relaunch.

## AI assistance

Parts of this change were written with AI assistance. All code was reviewed
and tested before submission, in line with the contribution guidelines.