### PR TITLE
Include more date components in schedule section header to fix a crash (really)

### DIFF
--- a/WWDC/ViewModels/SessionViewModel.swift
+++ b/WWDC/ViewModels/SessionViewModel.swift
@@ -464,12 +464,16 @@ final class SessionViewModel {
         return df
     }()
 
-    static let dayOfTheWeekFormatter: DateFormatter = {
+    static let dayFormatter: DateFormatter = {
         let df = DateFormatter()
 
         df.locale = Locale.current
         df.timeZone = TimeZone.current
-        df.dateFormat = "EEEE"
+        /// The date ends up becoming a key in an `OrderedDictionary`,
+        /// so to be safe we must include month and day of the month,
+        /// otherwise if Apple has events post-WWDC week, we end up
+        /// with duplicate dictionary keys that cause a crash at runtime.
+        df.dateFormat = "EEEE MMM d"
 
         return df
     }()
@@ -493,7 +497,7 @@ final class SessionViewModel {
     }
 
     static func standardFormatted(date: Date, withTimeZoneName: Bool) -> String {
-        let result = dayOfTheWeekFormatter.string(from: date) + ", " + timeFormatter.string(from: date)
+        let result = dayFormatter.string(from: date) + ", " + timeFormatter.string(from: date)
 
         return withTimeZoneName ? result + timeZoneNameSuffix : result
     }


### PR DESCRIPTION
This year Apple has decided to release content after the week of WWDC. This ended up causing a crash in the app because we're grouping contents by date in the schedule view, but the formatted header dates end up becoming the keys of an `OrderedDictionary`. This is a dirty fix that just adds the month and day of the month to the date format. I'm not proud of it, but it does the job.

In the meantime, I have disabled the offending content server-side to prevent the production app from crashing for everyone.